### PR TITLE
Use std::string when allowed to use libstdc++

### DIFF
--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -58,7 +58,7 @@ public:
 	}
 
 	/** assign a String */
-	const String& operator =(const String& a) {
+	String& operator =(const String& a) {
 		if (data)
 			delete[]data;
 
@@ -68,9 +68,9 @@ public:
 			data = new char[len];
 			memcpy(data, a.data, len);
 		} else
-			data = 0;
+			data = NULL;
 
-		return a;
+		return *this;
 	}
 
 	/** initialize with a character constant */
@@ -86,7 +86,7 @@ public:
 	}
 
 	/** assign a character constant */
-	const String& operator =(const char* msg) {
+	String& operator =(const char* msg) {
 		if (data)
 			delete[]data;
 

--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -20,7 +20,10 @@
 #ifndef MY_STRING_H
 #define MY_STRING_H
 
+/* This has to stay because other source files rely on it */
 #include <string.h>
+
+#ifdef USE_NOLIBSTDC /* Do not use the C++ Standard Library */
 
 /** implements a string */
 class String {
@@ -151,5 +154,57 @@ inline const String& operator +=(String& a, const String b) {
 	String c = a + b;
 	return (a = c);
 }
+
+#else /* Use the C++ Standard Library */
+
+#include <string>
+
+class String: public std::string {
+public:
+	/**
+	 * Construct an empty string.
+	 */
+	String() {}
+
+	/**
+	 * Copy constructor
+	 */
+	String(const String& lhs): std::string(lhs) {}
+
+	/**
+	 * Copy constructor
+	 */
+	String(const std::string& lhs): std::string(lhs) {}
+
+	/**
+	 * Copy constructor
+	 */
+	String(const char* lhs): std::string(lhs) {}
+
+	/**
+	 * Transform into a C-String
+	 */
+	const char* operator ()() const {
+		return c_str();
+	}
+
+	/**
+	 * Concatenation
+	 */
+	String operator +(const String& rhs) const {
+		return String(static_cast<const std::string&>(*this)
+		              + static_cast<const std::string&>(rhs));
+	}
+
+	/**
+	 * In-place concatenation
+	 */
+	const String& operator +=(const String& rhs) {
+		// Let's assume immutability
+		return (*this = *this + rhs);
+	}
+};
+
+#endif /* USE_NOLIBSTDC */
 
 #endif

--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -149,12 +149,6 @@ public:
 	}
 };
 
-/** adds a text to a string */
-inline const String& operator +=(String& a, const String b) {
-	String c = a + b;
-	return (a = c);
-}
-
 #else /* Use the C++ Standard Library */
 
 #include <string>
@@ -195,16 +189,15 @@ public:
 		return String(static_cast<const std::string&>(*this)
 		              + static_cast<const std::string&>(rhs));
 	}
-
-	/**
-	 * In-place concatenation
-	 */
-	inline String& operator +=(const String& rhs) {
-		// Let's assume immutability
-		return (*this = *this + rhs);
-	}
 };
 
 #endif /* USE_NOLIBSTDC */
+
+/**
+ * In-place string concatenation (sort of).
+ */
+inline String& operator +=(String& lhs, const String& rhs) {
+	return (lhs = lhs + rhs);
+}
 
 #endif

--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -199,7 +199,7 @@ public:
 	/**
 	 * In-place concatenation
 	 */
-	const String& operator +=(const String& rhs) {
+	inline const String& operator +=(const String& rhs) {
 		// Let's assume immutability
 		return (*this = *this + rhs);
 	}

--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -197,7 +197,24 @@ public:
  * In-place string concatenation (sort of).
  */
 inline String& operator +=(String& lhs, const String& rhs) {
-	return (lhs = lhs + rhs);
+	#ifdef USE_NOLIBSTDC /* Do not use the C++ Standard Library */
+		return (lhs = lhs + rhs);
+	#else /* Use the C++ Standard Library */
+		lhs.append(rhs);
+		return lhs;
+	#endif /* USE_NOLIBSTDC */
+}
+
+/**
+ * In-place string concatenation (sort of) with implicit conversion.
+ */
+inline String& operator +=(String& lhs, const char* rhs) {
+	#ifdef USE_NOLIBSTDC /* Do not use the C++ Standard Library */
+		return (lhs = lhs + rhs);
+	#else /* Use the C++ Standard Library */
+		lhs.append(rhs);
+		return lhs;
+	#endif /* USE_NOLIBSTDC */
 }
 
 #endif

--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -23,140 +23,133 @@
 #include <string.h>
 
 /** implements a string */
-class String
-{
-  /** content */
-  char *data;
-  /** length */
-  unsigned len;
+class String {
+	/** content */
+	char* data;
+
+	/** length */
+	unsigned len;
+
 public:
-  /** free memory */
-    virtual ~ String ()
-  {
-    if (data)
-      delete[]data;
-  }
+	/** free memory */
+	virtual ~String() {
+		if (data)
+			delete[]data;
+	}
 
-  /** initialize with the empty string */
-  String ()
-  {
-    data = 0;
-    len = 0;
-  }
+	/** initialize with the empty string */
+	String() {
+		data = 0;
+		len = 0;
+	}
 
-  /** initialize with a string */
-  String (const String & a)
-  {
-    len = a.len;
-    if (len)
-      {
-	data = new char[len];
-	memcpy (data, a.data, len);
-      }
-    else
-      data = 0;
-  }
-  /** assign a String */
-  const String & operator = (const String & a)
-  {
-    if (data)
-      delete[]data;
-    len = a.len;
-    if (len)
-      {
-	data = new char[len];
-	memcpy (data, a.data, len);
-      }
-    else
-      data = 0;
-    return a;
-  }
+	/** initialize with a string */
+	String(const String& a) {
+		len = a.len;
 
-  /** initialize with a character constant */
-  String (const char *msg)
-  {
-    if (msg)
-      {
-	len = strlen (msg) + 1;
-	data = new char[len];
-	strcpy (data, msg);
-      }
-    else
-      {
-	data = 0;
-	len = 0;
-      }
-  }
+		if (len) {
+			data = new char[len];
+			memcpy(data, a.data, len);
+		} else
+			data = 0;
+	}
 
-  /** assign a character constant */
-  const String & operator = (const char *msg)
-  {
-    if (data)
-      delete[]data;
-    if (msg)
-      {
-	len = strlen (msg) + 1;
-	data = new char[len];
-	strcpy (data, msg);
-      }
-    else
-      {
-	data = 0;
-	len = 0;
-      }
-    return *this;
-  }
+	/** assign a String */
+	const String& operator =(const String& a) {
+		if (data)
+			delete[]data;
 
-  /** concats two strings*/
-  String operator + (const String & a)
-  {
-    String b;
-    if (!len)
-      return a;
-    if (!a.len)
-      return *this;
-    b.len = a.len + len - 1;
-    if (b.len > 0)
-      {
-	b.data = new char[b.len];
-	if (data)
-	  strcpy (b.data, data);
-	else
-	  b.data[0] = 0;
-	if (a.data)
-	  strcat (b.data, a.data);
-      }
-    return b;
-  }
+		len = a.len;
 
-  bool operator == (const String & a) const
-  {
-    if (!a.len && !len)
-      return 1;
-    if (a.len != len)
-      return 0;
-    return (!strcmp (data, a.data));
-  }
+		if (len) {
+			data = new char[len];
+			memcpy(data, a.data, len);
+		} else
+			data = 0;
 
-  bool operator!= (const String & a) const
-  {
-    return !(*this == a);
-  }
+		return a;
+	}
 
-  /** returns the content as char* */
-  const char *operator  () () const
-  {
-    return data;
-  }
+	/** initialize with a character constant */
+	String(const char* msg) {
+		if (msg) {
+			len = strlen(msg) + 1;
+			data = new char[len];
+			strcpy(data, msg);
+		} else {
+			data = 0;
+			len = 0;
+		}
+	}
 
+	/** assign a character constant */
+	const String& operator =(const char* msg) {
+		if (data)
+			delete[]data;
+
+		if (msg) {
+			len = strlen(msg) + 1;
+			data = new char[len];
+			strcpy(data, msg);
+		} else {
+			data = 0;
+			len = 0;
+		}
+
+		return *this;
+	}
+
+	/** concats two strings*/
+	String operator +(const String& a) {
+		String b;
+
+		if (!len)
+			return a;
+
+		if (!a.len)
+			return *this;
+
+		b.len = a.len + len - 1;
+
+		if (b.len > 0) {
+			b.data = new char[b.len];
+
+			if (data)
+				strcpy(b.data, data);
+			else
+				b.data[0] = 0;
+
+			if (a.data)
+				strcat(b.data, a.data);
+		}
+
+		return b;
+	}
+
+	bool operator ==(const String& a) const {
+		if (!a.len && !len)
+			return 1;
+
+		if (a.len != len)
+			return 0;
+
+		return (!strcmp(data, a.data));
+	}
+
+	bool operator !=(const String& a) const {
+		return !(*this == a);
+	}
+
+	/** returns the content as char* */
+	const char* operator ()() const {
+		return data;
+	}
 };
 
 /** adds a text to a string */
-inline const String &
-operator += (String & a, const String b)
-{
-  String c = a + b;
-  return (a = c);
+inline const String& operator +=(String& a, const String b) {
+	String c = a + b;
+	return (a = c);
 }
 
 #endif

--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -17,8 +17,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MY_STRING_H
-#define MY_STRING_H
+#ifndef KNXD_COMMON_MYSTRING_H
+#define KNXD_COMMON_MYSTRING_H
 
 /* This has to stay because other source files rely on it */
 #include <string.h>

--- a/src/common/my_strings.h
+++ b/src/common/my_strings.h
@@ -103,7 +103,7 @@ public:
 	}
 
 	/** concats two strings*/
-	String operator +(const String& a) {
+	String operator +(const String& a) const {
 		String b;
 
 		if (!len)
@@ -199,7 +199,7 @@ public:
 	/**
 	 * In-place concatenation
 	 */
-	inline const String& operator +=(const String& rhs) {
+	inline String& operator +=(const String& rhs) {
 		// Let's assume immutability
 		return (*this = *this + rhs);
 	}


### PR DESCRIPTION
The internal string class follows a naive implementation, so it seems like a good idea to simply use `libstdc++`'s `std::string` when `--without-libstdc` is omitted from the configuration.
If `--without-libstdc` is given, it will use knxd's own implementation.