### PR TITLE
Update knxd.default

### DIFF
--- a/debian/knxd.default
+++ b/debian/knxd.default
@@ -6,7 +6,15 @@
 # This is a POSIX shell fragment
 #
 
-# Additional options that are passed to the Daemon.
+# start knxd when /etc/init.d/knxd start is run
+# by default knxd does NOT start. set to YES to enable
 START_KNXD=NO
 
-DAEMON_OPTS=""
+# Additional options that are passed to the Daemon.
+#
+# for IP interface at 192.168.178.123; 
+# local Unix Domain Socket /tmp/eib _not_ enabled (-u)
+# -d for daemonizing - running from init script!
+# DAEMON_ARGS="-c -d -S -D -R -T --no-tunnel-client-queuing -i ipt:192.168.178.123"
+DAEMON_ARGS=""
+


### PR DESCRIPTION
- fixed typo: DAEMON_ARGS instead of DAEMON_OPTS

- added example for IPT configuration as requested in issue #51
  (as running from init script, -t 1023 or omitting -d does not seem sensible)