### PR TITLE
Removed libatomic from ./configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ path.h : Makefile
 # source and binary RPMs
 #
 .PHONY:	RPM
-RPM:	dist
+RPM:	all dist
 	rm -f rpm/rpm-tmp.*
 	make -C rpm $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,6 @@ AM_CONDITIONAL(HAVE_SOURCE_INFO, test x$have_source_info = xyes )
 AC_CHECK_PROGS(INDENT, indent, no)
 AC_CHECK_PROGS(JAR, fastjar jar, no)
 AC_CHECK_PROGS(JAVAC, "gcj -C" javac, no)
-AC_CHECK_LIB([atomic], [__atomic_fetch_add_4], [LIBS="$LIBS -latomic"])
 
 AC_ARG_ENABLE(java,
 [  --enable-java		build java client library],

--- a/rpm/knxd.spec.in
+++ b/rpm/knxd.spec.in
@@ -8,6 +8,9 @@
 %define _srcrpmdir @abs_top_srcdir@/rpm/SRPMS
 %define _tmpdir    /tmp
 %define _buildrootdir @abs_top_srcdir@/rpm/BUILDROOT
+%define buildroot     @abs_top_srcdir@/rpm/BUILDROOT
+
+BuildRoot: %{buildroot}
 
 ###############################################################################
 #


### PR DESCRIPTION
Removed **libatomic** from **./configure** as suggested by Othmar.

Added dependency **RPM: all** so that the problem that was fixed by **libatomic** earlier does not occur any more.

Signed-off-by: Jürgen Sauermann juergen.sauermann@t-online.de