### PR TITLE
Fixing issue #89, vbusmonitor1time dies message "Open Busmonitor failed: Invalid argument"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,14 +1,17 @@
 Alphabetical list of surnames of everyone who ever committed to this repository.
 Auto-generated from tools/list_AUTHORS and .mailmap
 
+Thomas Dallmair <dallmair@users.noreply.github.com>
 Meik Felser <mfmailbox-bcusdk@yahoo.de>
 Richard Hartmann <richih@debian.org>
 Richard Hartmann <RichiH@users.noreply.github.com>
 Stefan Hoffmeister <stefan@hoffmeister.biz>
 J-N-K <jan.n.klug@rub.de>
 Marc Joliet <marcec@gmx.de>
+jsauermann <juergen.sauermann@t-online.de>
 Elias Karakoulakis <elias.karakoulakis@gmail.com>
 Michael Kefeder <m.kefeder@gmail.com>
+Claus Klingberg <cjk@pobox.com>
 Martin Koegler <mkoegler@auto.tuwien.ac.at>
 Ole Krüger <ole.krueger@campus.tu-berlin.de>
 Michael Markstaller <mm@elabnet.de>

--- a/src/examples/knxtool.c
+++ b/src/examples/knxtool.c
@@ -1466,10 +1466,10 @@ vbusmonitor1time\n");
 
       if (ac != 2)
 	die ("usage: %s url", prog);
+      con = open_con(ag[1]);
 
       if (EIBOpenVBusmonitorText (con) == -1)
 	die ("Open Busmonitor failed");
-      con = open_con(ag[1]);
 
       while (1)
 	{


### PR DESCRIPTION
The connection was used before it was opened, couldn't work this way.