### PR TITLE
Group cache must be initialized to work correctly

### DIFF
--- a/src/libserver/groupcacheclient.cpp
+++ b/src/libserver/groupcacheclient.cpp
@@ -27,6 +27,8 @@ bool
 CreateGroupCache (Layer3 * l3, Trace * t, bool enable)
 {
   cache = new GroupCache (l3, t);
+  if (!cache->init ())
+    return false;
   if (enable)
     if (!cache->Start ())
       return false;


### PR DESCRIPTION
Due to some code changes the group cache didn't work anymore. In the
BCU SDK it was special cased, now it's implemented as yet another Layer2
interface. However that means it has to be handled like an L2 interface,
especially the init() function must be called such that it can register
with the L3 object and participate in all messaging.

Fix #91

Signed-off-by: Thomas Dallmair <dallmair@users.noreply.github.com>