### PR TITLE
set debian format to native so that tools like sbuild don't bail out …

### DIFF
--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
…with an error