### PR TITLE
udev rules file added

### DIFF
--- a/contrib/udev/README.md
+++ b/contrib/udev/README.md
@@ -1,0 +1,10 @@
+udev rule file for KNX USB hid devices
+======================================
+
+This is a rule file to be put into `/etc/udev/rules.d`. Depending on your 
+distribution you can choose a numeric prefix to control the priority of the 
+already available rules in the directory (e.g. `90-knxd.rules`). USB devices for 
+KNX access will have access rights for user *knxd* which give the KNXd process 
+(if started as user knxd) read and write access to the devices and therefore has 
+not to be run as root. This is compatible with systemd files and the debian 
+packages.

--- a/contrib/udev/knxd.rules
+++ b/contrib/udev/knxd.rules
@@ -1,0 +1,37 @@
+# udev rule file
+# grants knxd access to USB knx interfaces
+
+# Schlaps&Partner: EIB-USB Data Interface [Philips Semiconductors]
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="04cc", ATTR{idProduct}=="0301",GROUP="knxd",MODE="0660"
+# Siemens AG: KNX/EIB-USB Interface (DIN rail)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="0e77", ATTR{idProduct}=="0112",GROUP="knxd",MODE="0660"
+# Siemens AG: KNX/EIB-USB Interface (Flush mounted)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="0e77", ATTR{idProduct}=="0111",GROUP="knxd",MODE="0660"
+# Weinzierl Engineering GmbH: KNX-USB Data Interface (UP)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="0e77", ATTR{idProduct}=="0102",GROUP="knxd",MODE="0660"
+# Weinzierl Engineering GmbH: KNX-USB Data Interface
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="0e77", ATTR{idProduct}=="0103",GROUP="knxd",MODE="0660"
+# Weinzierl Engineering GmbH: KNX-USB Data Interface (Weinzierl/Lingg&Janke DIN-rail)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="0e77", ATTR{idProduct}=="0104",GROUP="knxd",MODE="0660"
+# Weinzierl Engineering GmbH: KNX-USB Data Interface (Hensel DIN-rail)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="0e77", ATTR{idProduct}=="0121",GROUP="knxd",MODE="0660"
+# Weinzierl Engineering GmbH: KNX-USB Data Interface (MerlinGerin UP)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="0e77", ATTR{idProduct}=="0141",GROUP="knxd",MODE="0660"
+# Insta Elektro GmbH: KNX-USB Data Interface
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="135e", ATTR{idProduct}=="0020",GROUP="knxd",MODE="0660"
+# Insta Elektro GmbH: KNX-USB Data Interface (Berker)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="135e", ATTR{idProduct}=="0021",GROUP="knxd",MODE="0660"
+# Insta Elektro GmbH: KNX-USB Data Interface (Gira)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="135e", ATTR{idProduct}=="0022",GROUP="knxd",MODE="0660"
+# Insta Elektro GmbH: KNX-USB Data Interface (Jung)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="135e", ATTR{idProduct}=="0023",GROUP="knxd",MODE="0660"
+# Insta Elektro GmbH: KNX-USB Data Interface (Merten)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="135e", ATTR{idProduct}=="0024",GROUP="knxd",MODE="0660"
+# Hager Electro: KNX-USB Data Interface [Insta Elektro GmbH]
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="135e", ATTR{idProduct}=="0025",GROUP="knxd",MODE="0660"
+# Insta Elektro GmbH: KNX-USB Data Interface (Feller)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="135e", ATTR{idProduct}=="0026",GROUP="knxd",MODE="0660"
+# Busch-Jaeger Elektro GmbH: KNX-USB Interface (Flush mounted) [Typ 6133]
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="145c", ATTR{idProduct}=="1330",GROUP="knxd",MODE="0660"
+# ABB STOTZ-KONTAKT GmbH: KNX-USB Interface (REG)
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTR{idVendor}=="147b", ATTR{idProduct}=="5120",GROUP="knxd",MODE="0660"


### PR DESCRIPTION
Added an udev rules file to give knxd access to common KNX/USB interfaces.

May be included into packages to ease the use of USB interfaces.