### PR TITLE
Fix two segmentation fault bugs.

### DIFF
--- a/src/libserver/layer3.cpp
+++ b/src/libserver/layer3.cpp
@@ -198,6 +198,20 @@ Layer3::registerLayer2 (Layer2 * l2)
 }
 
 bool
+Layer3::layer2Registered(Layer2 * l2)
+{
+  unsigned i;
+  for (i = 0; i < layer2 (); i++)
+    if (layer2[i] == l2)
+      {
+	TRACEPRINTF (t, 3, this, "Layer2 %08X is registered.", l2);
+	return 1;
+      }
+  TRACEPRINTF (t, 3, this, "Layer2 %08X is NOT registered.", l2);
+  return 0;
+}
+
+bool
 Layer3::hasAddress (eibaddr_t addr, Layer2 *l2)
 {
   if (addr == defaultAddr)
@@ -299,10 +313,14 @@ Layer3::Run (pth_sem_t * stop1)
 	  ignore[ignore () - 1].end = getTime () + 1000000;
 	  l1->repeated = 0;
 
-	  if (l1->source != 0 && l1->source != defaultAddr)
-	    l1->l2->addAddress (l1->source);
-	  else if (l1->AddrType == IndividualAddress && l1->dest != defaultAddr)
-	    l1->l2->addReverseAddress (l1->dest);
+	  if (layer2Registered(l1->l2)) {
+		  if (l1->source != 0 && l1->source != defaultAddr) {
+		    l1->l2->addAddress (l1->source);
+		  }
+		  else if (l1->AddrType == IndividualAddress && l1->dest != defaultAddr) {
+		    l1->l2->addReverseAddress (l1->dest);
+		  }
+	  }
 
 	  if (l1->AddrType == IndividualAddress
 	      && l1->dest == defaultAddr)

--- a/src/libserver/layer3.h
+++ b/src/libserver/layer3.h
@@ -92,6 +92,8 @@ public:
   bool registerLayer2 (Layer2 * l2);
   /** deregister a layer2 interface, return true if successful*/
   bool deregisterLayer2 (Layer2 * l2);
+  /** check if a layer2 interface has been registered, return true if successful*/
+  bool layer2Registered(Layer2 * l2);
 
   /** register a busmonitor callback, return true, if successful*/
   bool registerBusmonitor (L_Busmonitor_CallBack * c);

--- a/src/libserver/layer7.cpp
+++ b/src/libserver/layer7.cpp
@@ -79,8 +79,8 @@ Array < eibaddr_t >
 
 Layer7_Connection::Layer7_Connection (Layer3 * l3, Trace * tr, eibaddr_t d)
 {
-  TRACEPRINTF (t, 5, this, "L7Connection open");
   t = tr;
+  TRACEPRINTF (t, 5, this, "L7Connection open");
   dest = d;
   l4 = new T_Connection (l3, tr, d);
   if (!l4->init ())


### PR DESCRIPTION
Hi. For a friend I am setting up a KNX system but during testing and trying to work outside of ETS I ran into "segmentation faults" when I ran a "knxtool writeaddress" call.

First segmentation fault was easy to find where it tried to access an uninitialized pointer in a trace print.
Second segmentation fault took a bit longer and has to do with a layer2 getting destroyed, the layer3 is getting notified about it but it never checks its list of registered layer2 interfaces before it accesses a layer2. This fixes adds the check.