### PR TITLE
Correct invalid length of L_Busmon.ind field for busmonitor mode (stable)

### DIFF
--- a/src/libserver/emi.cpp
+++ b/src/libserver/emi.cpp
@@ -132,14 +132,13 @@ CArray
 Busmonitor_to_CEMI (uchar code, const L_Busmonitor_PDU & p, int no)
 {
   CArray pdu;
-  pdu.resize (p.pdu () + 6);
+  pdu.resize (p.pdu () + 5);
   pdu[0] = code;
-  pdu[1] = 4;
-  pdu[2] = 3;
-  pdu[3] = 1;
-  pdu[4] = 1;
-  pdu[5] = no & 0x7;
-  pdu.setpart (p.pdu, 6);
+  pdu[1] = 3;        /* AddIL */
+  pdu[2] = 3;        /* Type ID = L_Busmon.ind */
+  pdu[3] = 1;        /* Len */
+  pdu[4] = no & 0x7; /* Status */
+  pdu.setpart (p.pdu, 5);
   return pdu;
 }
 


### PR DESCRIPTION
This is a more complete correction to the one mentioned by @jodamm in 2fd0c7a03705cac0e98e8049b88502ab65c14d22. He had forgotten to adjust the AddIL field length.