### PR TITLE
Fixing issues #121, ACKs too late

### DIFF
--- a/src/backend/tpuartserial.cpp
+++ b/src/backend/tpuartserial.cpp
@@ -318,16 +318,7 @@ TPUARTSerialLayer2Driver::Run (pth_sem_t * stop1)
 	    {
               bool recvecho = false;
 
-/*  The following line used to be:
- *
- *            if (in () < 6)
- *
- * On a Raspberry Pi this resulted in the ACK being sent over the tpuart serial
- * interface while the reception of the KNX Telegram was still ongoing (around
- * byte 8 of the telegram). The ELMOS chip ignores such ACKs (that were sent
- * too early).
- */
-	      if (in() < 8 || in() < (8 + (in[5] & 0x0F)))  // Telegram complete
+              if (in () < 6)
 		{
 		  if (!to)
 		    {


### PR DESCRIPTION
This patch appears to bring timing problems to Raspberry PIs and TPUARTS if the packet is *not*
acknowledged early enough. Should fix issue #121.
Reverting commit dcbbbd334342ae6279569260a2e68c4034a4ad05

Signed-off-by: Stefan Michaelis <stefan.michaelis@gmx.de>