### PR TITLE
Make sure we indicate success on disconnect

### DIFF
--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -474,6 +474,7 @@ EIBnetServer::drop_state (uint8_t index)
 
 ConnState::~ConnState()
 {
+  TRACEPRINTF (parent->t, 8, this, "CloseS");
   Stop();
   pth_event_free (timeout, PTH_FREE_THIS);
   pth_event_free (sendtimeout, PTH_FREE_THIS);

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -820,8 +820,12 @@ EIBnetServer::Run (pth_sem_t * stop1)
       if (p1)
 	handle_packet (p1, this->sock);
     }
-  for (i = 0; i < state (); i++)
-    state[i] = nullptr;
+
+  /* copy aray since shutdown will mutate this */
+  Array<ConnStatePtr> state2 = state;
+  state.resize(0);
+  for (i = 0; i < state2 (); i++)
+    state2[i]->shutdown();
   pth_event_free (stop, PTH_FREE_THIS);
 }
 

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -469,8 +469,9 @@ void EIBnetServer::drop_state (ConnStatePtr s)
 void
 EIBnetServer::drop_state (uint8_t index)
 {
-  /* Stop state, it will de-register itself. index is invalid after this */
-  state[index]->shutdown();
+  ConnStatePtr state2 = state[index];
+  state.deletepart (index);
+  state2->shutdown();
 }
 
 ConnState::~ConnState()

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -435,7 +435,7 @@ ConnState::Run (pth_sem_t * stop1)
         }
     }
 
-  if (pth_event_status (stop) != PTH_STATUS_OCCURRED)
+  if (channel > 0)
     {
       EIBnet_DisconnectRequest r;
       r.channel = channel;
@@ -656,6 +656,7 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
 	    if (compareIPAddress (p1->src, state[i]->caddr))
 	      {
 		res = 0;
+		state[i]->channel = 0;
 		drop_state(i);
 		break;
 	      }

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -726,7 +726,7 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
 		TRACEPRINTF (t, 8, this, "Invalid data endpoint");
 		break;
 	      }
-	    state[i]->tunnel_request(r1);
+	    state[i]->tunnel_request(r1, isock);
 	    break;
 	  }
       goto out;
@@ -838,7 +838,7 @@ EIBnetDiscover::Run (pth_sem_t * stop1)
   pth_event_free (stop, PTH_FREE_THIS);
 }
 
-void ConnState::tunnel_request(EIBnet_TunnelRequest &r1)
+void ConnState::tunnel_request(EIBnet_TunnelRequest &r1, EIBNetIPSocket *isock)
 {
   EIBnet_TunnelACK r2;
   r2.channel = r1.channel;
@@ -891,7 +891,7 @@ void ConnState::tunnel_request(EIBnet_TunnelRequest &r1)
       r2.status = 0x29;
     }
   rno++;
-  parent->Send (r2.ToPacket (), daddr);
+  isock->Send (r2.ToPacket (), daddr);
 }
 
 void ConnState::tunnel_response (EIBnet_TunnelACK &r1)

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -398,7 +398,7 @@ ConnState::Run (pth_sem_t * stop1)
 
       if (pth_event_status (timeout) == PTH_STATUS_OCCURRED)
 	{
-	  shutdown();
+	  parent->drop_state (std::static_pointer_cast<ConnState>(shared_from_this()));
 	  return;
 	}
       if (state ? pth_event_status (sendtimeout) == PTH_STATUS_OCCURRED
@@ -445,12 +445,12 @@ ConnState::Run (pth_sem_t * stop1)
       r.nat = nat;
       parent->Send (r.ToPacket (), caddr);
     }
-  shutdown();
+  parent->drop_state (std::static_pointer_cast<ConnState>(shared_from_this()));
 }
 
 void ConnState::shutdown(void)
 {
-  parent->drop_state (std::static_pointer_cast<ConnState>(shared_from_this()));
+  Stop();
 }
 
 void EIBnetServer::drop_state (ConnStatePtr s)
@@ -468,8 +468,8 @@ void EIBnetServer::drop_state (ConnStatePtr s)
 void
 EIBnetServer::drop_state (uint8_t index)
 {
-  // delete state[index];
-  state.deletepart (index);
+  /* Stop state, it will de-register itself. index is invalid after this */
+  state[index]->shutdown();
 }
 
 ConnState::~ConnState()

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -652,6 +652,7 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
 	  {
 	    if (compareIPAddress (p1->src, state[i]->caddr))
 	      {
+		res = 0;
 		drop_state(i);
 		break;
 	      }

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -848,7 +848,7 @@ void ConnState::tunnel_request(EIBnet_TunnelRequest &r1, EIBNetIPSocket *isock)
   if (rno == ((r1.seqno + 1) & 0xff))
     {
       TRACEPRINTF (t, 8, this, "Lost ACK for %d", rno);
-      parent->Send (r2.ToPacket (), daddr);
+      isock->Send (r2.ToPacket (), daddr);
       return;
     }
   if (rno != r1.seqno)
@@ -931,7 +931,7 @@ void ConnState::config_request(EIBnet_ConfigRequest &r1, EIBNetIPSocket *isock)
     {
       r2.channel = r1.channel;
       r2.seqno = r1.seqno;
-      parent->Send (r2.ToPacket (), daddr);
+      isock->Send (r2.ToPacket (), daddr);
       return;
     }
   if (rno != r1.seqno)

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -397,10 +397,8 @@ ConnState::Run (pth_sem_t * stop1)
       pth_event_isolate (outwait);
 
       if (pth_event_status (timeout) == PTH_STATUS_OCCURRED)
-	{
-	  parent->drop_state (std::static_pointer_cast<ConnState>(shared_from_this()));
-	  return;
-	}
+        break;
+
       if (state ? pth_event_status (sendtimeout) == PTH_STATUS_OCCURRED
                 : !out.isempty ())
 	{
@@ -437,13 +435,16 @@ ConnState::Run (pth_sem_t * stop1)
         }
     }
 
-  EIBnet_DisconnectRequest r;
-  r.channel = channel;
-  if (GetSourceAddress (&caddr, &r.caddr))
+  if (pth_event_status (stop) != PTH_STATUS_OCCURRED)
     {
-      r.caddr.sin_port = parent->Port;
-      r.nat = nat;
-      parent->Send (r.ToPacket (), caddr);
+      EIBnet_DisconnectRequest r;
+      r.channel = channel;
+      if (GetSourceAddress (&caddr, &r.caddr))
+        {
+          r.caddr.sin_port = parent->Port;
+          r.nat = nat;
+          parent->Send (r.ToPacket (), caddr);
+        }
     }
   parent->drop_state (std::static_pointer_cast<ConnState>(shared_from_this()));
 }

--- a/src/libserver/eibnetserver.h
+++ b/src/libserver/eibnetserver.h
@@ -63,7 +63,7 @@ public:
   pth_event_t sendtimeout;
 
   // handle various packets from the connection
-  void tunnel_request(EIBnet_TunnelRequest &r1);
+  void tunnel_request(EIBnet_TunnelRequest &r1, EIBNetIPSocket *isock);
   void tunnel_response(EIBnet_TunnelACK &r1);
   void config_request(EIBnet_ConfigRequest &r1, EIBNetIPSocket *isock);
   void config_response (EIBnet_ConfigACK &r1);

--- a/src/libserver/eibnetserver.h
+++ b/src/libserver/eibnetserver.h
@@ -35,6 +35,8 @@ typedef enum {
 
 class ConnState: protected Thread, public Layer2mixin
 {
+  virtual void RunDone() { Layer2mixin::RunStop(); }
+
 public:
   ConnState (EIBnetServer *p, eibaddr_t addr);
   ~ConnState ();

--- a/src/libserver/layer2.h
+++ b/src/libserver/layer2.h
@@ -42,10 +42,10 @@ class Layer2 : public std::enable_shared_from_this<Layer2>
 
   bool allow_monitor;
 
+protected:
   /** auto-deregister for "tasked" layer2 objects */
   void RunStop();
 
-protected:
   /** auto-assigned. NON-bus connections only! */
   eibaddr_t remoteAddr;
 


### PR DESCRIPTION
* Signal success on disconnects to ETS5
* Signal disconnection of busmon/groupmon to ETS5 on knxd shutdown (note, fails in NAT mode since apperently ETS5 only accepts data originating from the multicast socket)
* Signal tunnel requests/config request ack back to client from same socket as request