### PR TITLE
Support double tunnel scenario

### DIFF
--- a/src/backend/eibnettunnel.cpp
+++ b/src/backend/eibnettunnel.cpp
@@ -84,6 +84,8 @@ bool EIBNetIPTunnel::init (Layer3 *l3)
     return false;
   if (! addGroupAddress(0))
     return false;
+  if (! addAddress(0))
+    return false;
   return Layer2::init (l3);
 }
 

--- a/src/backend/eibnettunnel.cpp
+++ b/src/backend/eibnettunnel.cpp
@@ -141,7 +141,6 @@ EIBNetIPTunnel::Run (pth_sem_t * stop1)
   int retry = 0;
   int heartbeat = 0;
   int drop = 0;
-  eibaddr_t myaddr = 0;
   pth_event_t stop = pth_event (PTH_EVENT_SEM, stop1);
   pth_event_t input = pth_event (PTH_EVENT_SEM, &insignal);
   pth_event_t timeout = pth_event (PTH_EVENT_RTIME, pth_time (0, 0));
@@ -220,7 +219,7 @@ EIBNetIPTunnel::Run (pth_sem_t * stop1)
 		  TRACEPRINTF (t, 1, this, "Recv wrong connection response");
 		  break;
 		}
-	      myaddr = (cresp.CRD[1] << 8) | cresp.CRD[2];
+	      addAddress((cresp.CRD[1] << 8) | cresp.CRD[2]);
 	      daddr = cresp.daddr;
 	      if (!cresp.nat)
 		{
@@ -317,7 +316,7 @@ EIBNetIPTunnel::Run (pth_sem_t * stop1)
 		  if (mode != BUSMODE_MONITOR)
 		    {
 		      if (c->AddrType == IndividualAddress
-			  && c->dest == myaddr)
+			  && hasAddress(c->dest))
 			c->dest = 0;
 		      l3->recv_L_Data (c);
 		      break;

--- a/src/backend/eibnettunnel.cpp
+++ b/src/backend/eibnettunnel.cpp
@@ -98,8 +98,16 @@ EIBNetIPTunnel::Send_L_Data (LPDU * l)
       delete l;
       return;
     }
-  L_Data_PDU *l1 = (L_Data_PDU *) l;
-  inqueue.put (L_Data_ToCEMI (0x11, *l1));
+
+  /* when tunneling physical requests, replies must be sent
+   * back to tunnel address instead of the real address  otherwise
+   * they will not be sent up
+   * the tunnling connection  */
+  L_Data_PDU l1 = *(L_Data_PDU *)l;
+  if (l1.AddrType == IndividualAddress)
+    l1.source = 0;
+
+  inqueue.put (L_Data_ToCEMI (0x11, l1));
   pth_sem_inc (&insignal, 1);
   delete l;
 }

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -374,6 +374,8 @@ ConnState::ConnState (EIBnetServer *p, eibaddr_t addr)
   sendtimeout = pth_event (PTH_EVENT_RTIME, pth_time (1, 0));
   if (!addr)
     remoteAddr = p->l3->get_client_addr ();
+  else
+    remoteAddr = addr;
   if (remoteAddr)
     addAddress(remoteAddr);
 }
@@ -872,6 +874,8 @@ void ConnState::tunnel_request(EIBnet_TunnelRequest &r1, EIBNetIPSocket *isock)
 	  if (c->hopcount)
 	    {
 	      c->hopcount--;
+              if (c->source == 0)
+                c->source = remoteAddr;
 	      if (r1.CEMI[0] == 0x11)
 		{
 		  out.put (L_Data_ToCEMI (0x2E, *c));

--- a/src/libserver/layer2.cpp
+++ b/src/libserver/layer2.cpp
@@ -53,8 +53,6 @@ Layer2::RunStop()
 bool
 Layer2::addAddress (eibaddr_t addr)
 {
-  if (addr == 0)
-    return false;
   unsigned i;
   for (i = 0; i < indaddr (); i++)
     if (indaddr[i] == addr)

--- a/src/libserver/layer3.cpp
+++ b/src/libserver/layer3.cpp
@@ -314,7 +314,7 @@ Layer3::Run (pth_sem_t * stop1)
               l1->source = l2->remoteAddr ? l2->remoteAddr : defaultAddr;
             if (l1->source != defaultAddr)
               l2->addAddress (l1->source);
-            else if (l1->AddrType == IndividualAddress && l1->dest != defaultAddr)
+            if (l1->AddrType == IndividualAddress && !l2->hasAddress(l1->dest))
               l2->addReverseAddress (l1->dest);
           }
 


### PR DESCRIPTION
This (reinstates?) double tunnel support:

TP -> ABB IPR/S --tunnel_1--> knxd --tunnel_2-> ETS5

With this i at least get Device Info from ETS5.

The main gist is that 
* we need to consider the tunnel_1 a bus device, so all messages get sent down that hole, no only seen devices. 
* we must make physical packets going out tunnel_1 be source from the tunnel, so replies get back to tunnel.
* the uggly... re-allow layer2 devices with 0 as their own address. one option could be to set line mask instead. Ie say that all addresses target at the same line as the tunnel device should go down that route.

Two steps that might not be needed, but seem correct.
* we need to make sure tunnel_2 has a proper address stored as it's own address instead of only keeping it on stack.
* we need to make sure tunnel_2 layer2 device use it's own tunnel address, and not the defaultAddr in layer3 as the source of packets with zero source .