### PR TITLE
Don't check source address of commands

### DIFF
--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -631,13 +631,8 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       for (unsigned int i = 0; i < state (); i++)
 	if (state[i]->channel == r1.channel)
 	  {
-	    if (compareIPAddress (p1->src, state[i]->caddr))
-	      {
-		res = 0;
-                reset_time(state[i]->timeout, 120,0);
-	      }
-	    else
-	      TRACEPRINTF (t, 8, this, "Invalid control address");
+            res = 0;
+            reset_time(state[i]->timeout, 120,0);
 	  }
       r2.channel = r1.channel;
       r2.status = res;
@@ -654,15 +649,10 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       for (unsigned int i = 0; i < state (); i++)
 	if (state[i]->channel == r1.channel)
 	  {
-	    if (compareIPAddress (p1->src, state[i]->caddr))
-	      {
-		res = 0;
-		state[i]->channel = 0;
-		drop_state(i);
-		break;
-	      }
-	    else
-	      TRACEPRINTF (t, 8, this, "Invalid control address");
+            res = 0;
+            state[i]->channel = 0;
+            drop_state(i);
+            break;
 	  }
       r2.channel = r1.channel;
       r2.status = res;
@@ -724,11 +714,6 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       for (unsigned int i = 0; i < state (); i++)
 	if (state[i]->channel == r1.channel)
 	  {
-	    if (!compareIPAddress (p1->src, state[i]->daddr))
-	      {
-		TRACEPRINTF (t, 8, this, "Invalid data endpoint");
-		break;
-	      }
 	    state[i]->tunnel_request(r1, isock);
 	    break;
 	  }
@@ -743,11 +728,6 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       for (unsigned int i = 0; i < state (); i++)
 	if (state[i]->channel == r1.channel)
 	  {
-	    if (!compareIPAddress (p1->src, state[i]->daddr))
-	      {
-		TRACEPRINTF (t, 8, this, "Invalid data endpoint");
-		break;
-	      }
 	    state[i]->tunnel_response (r1);
 	    break;
 	  }
@@ -763,11 +743,6 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       for (unsigned int i = 0; i < state (); i++)
 	if (state[i]->channel == r1.channel)
 	  {
-	    if (!compareIPAddress (p1->src, state[i]->daddr))
-	      {
-		TRACEPRINTF (t, 8, this, "Invalid data endpoint");
-		  break;
-	      }
 	    state[i]->config_request (r1, isock);
 	    break;
 	  }
@@ -782,11 +757,6 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       for (unsigned int i = 0; i < state (); i++)
 	if (state[i]->channel == r1.channel)
 	  {
-	    if (!compareIPAddress (p1->src, state[i]->daddr))
-	      {
-		TRACEPRINTF (t, 8, this, "Invalid data endpoint");
-		break;
-	      }
 	    state[i]->config_response (r1);
 	    break;
 	  }


### PR DESCRIPTION
The client may use multiple sending ports. ETS5.5.2 uses both control and data endpoint as the source for requests.

Spec normally says that ip level information should be ignored.