### PR TITLE
Replace source address with 0 for physically targetted messages

### DIFF
--- a/src/backend/eibnettunnel.cpp
+++ b/src/backend/eibnettunnel.cpp
@@ -95,8 +95,16 @@ EIBNetIPTunnel::Send_L_Data (LPDU * l)
       delete l;
       return;
     }
-  L_Data_PDU *l1 = (L_Data_PDU *) l;
-  inqueue.put (L_Data_ToCEMI (0x11, *l1));
+
+  /* when tunneling physical requests, replies must be sent
+   * back to tunnel address instead of the real address  otherwise
+   * they will not be sent up
+   * the tunnling connection  */
+  L_Data_PDU l1 = *(L_Data_PDU *)l;
+  if (l1.AddrType == IndividualAddress)
+    l1.source = 0;
+
+  inqueue.put (L_Data_ToCEMI (0x11, l1));
   pth_sem_inc (&insignal, 1);
   if (mode == BUSMODE_VMONITOR)
     {


### PR DESCRIPTION
Replies to a physcially addressed request will not be sent back
to the tunneling device, unless the source address matches the
tunnel address. So we set the source to 0, which indicate to
tunnel server to use the tunnel address.