### PR TITLE
modified to work with CentOS7 (or at all?)

### DIFF
--- a/rpm/knxd.spec.in
+++ b/rpm/knxd.spec.in
@@ -11,6 +11,7 @@
 %define buildroot     @abs_top_srcdir@/rpm/BUILDROOT
 
 BuildRoot: %{buildroot}
+BuildRequires: systemd
 
 ###############################################################################
 #
@@ -33,7 +34,7 @@ Packager:     Dr. Jürgen Sauermann <juergen.sauermann@t-online.de>
 # Description.
 #
 %description
-A KNX daemon 9aka. EIN daemon) and tools supporting it. 
+A KNX daemon and tools supporting it. 
 
 ###############################################################################
 #
@@ -57,8 +58,14 @@ make
 #
 %install
 rm -rf %{buildroot}
+mkdir -p %{buildroot}%{_sysconfdir}/
+mkdir -p %{buildroot}%{_unitdir}/
+mkdir -p %{buildroot}%{_sysusersdir}/
 make DESTDIR=%{buildroot} install
-
+install -m 644 %{_sourcedir}/systemd/knxd.service %{buildroot}%{_unitdir}/knxd.service
+install -m 644 %{_sourcedir}/systemd/knxd.socket %{buildroot}%{_unitdir}/knxd.socket
+install -m 644 %{_sourcedir}/systemd/sysusers.d/knxd.conf %{buildroot}%{_sysusersdir}/knxd.conf
+install -m 644 %{_sourcedir}/systemd/knxd.conf %{buildroot}%{_sysconfdir}/knxd.conf
 
 ###############################################################################
 #
@@ -68,7 +75,7 @@ make DESTDIR=%{buildroot} install
 %defattr(-,root,root,-)
 
 # /etc
-%{_sysconfdir}/knxd.conf
+%config(noreplace) %{_sysconfdir}/knxd.conf
 
 # /usr/bin
 %{_bindir}/bcuaddrtab
@@ -143,9 +150,9 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/libeibclient.so
 %{_libdir}/libeibclient.so.0
 %{_libdir}/libeibclient.so.0.0.0
-%{_libdir}/systemd/system/knxd.service
-%{_libdir}/systemd/system/knxd.socket
-%{_libdir}/sysusers.d/knxd.conf
+%{_unitdir}/knxd.service
+%{_unitdir}/knxd.socket
+%{_sysusersdir}/knxd.conf
 
 # /usr/share/knxd/
 %{_datarootdir}/knxd/EIBConnection.cs
@@ -209,6 +216,10 @@ make DESTDIR=%{buildroot} install
 %{_datarootdir}/knxd/examples/writeaddress.c
 %{_datarootdir}/knxd/examples/xpropread.c
 %{_datarootdir}/knxd/examples/xpropwrite.c
+
+%exclude
+%{_datarootdir}/knxd/EIBConnection.pyc
+%{_datarootdir}/knxd/EIBConnection.pyo
 
 ###############################################################################
 #


### PR DESCRIPTION
This should help with issue #139 
The spec file is very unusual, redefining buildroot and stuff. Maybe someone with better rpmbuild background should rewrite this one. I only quickfixed. Also now this spec will now likely _only_ build on CentOS 7 (or other rpm based distros with systemd). I assume we'd have to create separate spec files for older centos releases (no clue how that's done best with automake,...). Finally - I cannot test knxd, as I ran it on a VM without any knx devices attached, rpm install works, if the config/daemon really is in a usable state another volunteer has to figure out.

Here is what I did to build the rpm - maybe add that to the wiki entry about rpm building?

```
sudo yum -y install git rpm-build make gcc gcc-c++ libtool vim-enhanced
wget https://www.auto.tuwien.ac.at/~mkoegler/pth/pthsem_2.0.8.tar.gz
rpmbuild -ta pthsem_2.0.8.tar.gz
sudo rpm -i ~/rpmbuild/RPMS/x86_64/*.rpm
git clone knxd
cd knxd
git checkout stable
mkdir -p rpm/{SRPMS,RPMS}
./bootstrap.sh
./configure
rpmbuild -ba rpm/knxd.spec
sudo rpm -i rpm/RPMS/x86_64/knxd-0.10.14-0.x86_64.rpm
```