### PR TITLE
Fix routing counter=7 on packets sent by knxtool (issue #45)

### DIFF
--- a/src/libserver/layer4.cpp
+++ b/src/libserver/layer4.cpp
@@ -85,6 +85,7 @@ T_Broadcast::Send (const CArray & c)
   l->dest = 0;
   l->AddrType = GroupAddress;
   l->data = t.ToPacket ();
+  l->hopcount = 0x07;
   l3->recv_L_Data (l);
 }
 

--- a/src/libserver/lpdu.cpp
+++ b/src/libserver/lpdu.cpp
@@ -212,7 +212,7 @@ L_Data_PDU::L_Data_PDU (Layer2Ptr layer2) : LPDU(layer2)
   AddrType = IndividualAddress;
   source = 0;
   dest = 0;
-  hopcount = 0x07;
+  hopcount = 0x06;
 }
 
 bool


### PR DESCRIPTION
Previously, the default hop count of every L_Data_PDU was 7, so that value was
used for every packet originating in clients like knxtool. Change this to only
set the value 7 explicitly for requests coming in through T_Broadcast, and set
the default to 6 instead (used for T_Group, T_TPDU, T_Individual, T_Connection,
and GroupSocket).

Signed-off-by: Thomas Dallmair <dallmair@users.noreply.github.com>