### PR TITLE
Fix memory leak on client requests

### DIFF
--- a/src/libserver/connection.cpp
+++ b/src/libserver/connection.cpp
@@ -146,36 +146,48 @@ A_Broadcast::~A_Broadcast ()
 {
   TRACEPRINTF (con->t, 7, this, "CloseBroadcast");
   Stop ();
+  if (c)
+    c->cleanup ();
 }
 
 A_Group::~A_Group ()
 {
   TRACEPRINTF (con->t, 7, this, "CloseGroup");
   Stop ();
+  if (c)
+    c->cleanup ();
 }
 
 A_TPDU::~A_TPDU ()
 {
   TRACEPRINTF (con->t, 7, this, "CloseTPDU");
   Stop ();
+  if (c)
+    c->cleanup ();
 }
 
 A_Individual::~A_Individual ()
 {
   TRACEPRINTF (con->t, 7, this, "CloseIndividual");
   Stop ();
+  if (c)
+    c->cleanup ();
 }
 
 A_Connection::~A_Connection ()
 {
   TRACEPRINTF (con->t, 7, this, "CloseConnection");
   Stop ();
+  if (c)
+    c->cleanup ();
 }
 
 A_GroupSocket::~A_GroupSocket ()
 {
   TRACEPRINTF (con->t, 7, this, "CloseGroupSocket");
   Stop ();
+  if (c)
+    c->cleanup ();
 }
 
 void

--- a/src/libserver/layer4.h
+++ b/src/libserver/layer4.h
@@ -67,6 +67,7 @@ protected:
   bool init_ok;
 public:
   bool init (Layer3 *l3);
+  void cleanup () { Layer2mixin::RunStop(); }
 };
 
 /** Broadcast Layer 4 connection */


### PR DESCRIPTION
The client request is mapped to the requested handler (e.g. A_Group), which
creates a layer 4 object (e.g. T_Group) in its constructor and registers that
one with the connection's layer 3 object. But the l3 object lives as long as the
process and keeps all the l2's around all the time.

Solution is to unregister the layer 2 on deconstruction of the request handler.

Signed-off-by: Thomas Dallmair <dallmair@users.noreply.github.com>