### PR TITLE
Fix USB interface shutdown bug already mentioned by mike-kfed in #10

### DIFF
--- a/src/backend/usbif.cpp
+++ b/src/backend/usbif.cpp
@@ -514,11 +514,13 @@ USBLowLevelDriver::Run (pth_sem_t * stop1)
   if (sendh)
     {
       libusb_cancel_transfer (sendh);
+      pth_wait (sende);
       libusb_free_transfer (sendh);
     }
   if (recvh)
     {
       libusb_cancel_transfer (recvh);
+      pth_wait (recve);
       libusb_free_transfer (recvh);
     }
   pth_event_free (stop, PTH_FREE_THIS);


### PR DESCRIPTION
After cancelling the outstanding send and receive transfers, we have to wait
until the corresponding callback functions have been called before we free the
underlying stack allocated memory by returning from the function.

Signed-off-by: Thomas Dallmair <dallmair@users.noreply.github.com>