### PR TITLE
Go (golang) client language binding for knxd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -314,7 +314,7 @@ AC_OUTPUT(Makefile
 src/common/Makefile
 src/Makefile src/include/Makefile  src/client/Makefile src/examples/Makefile src/libserver/Makefile src/server/Makefile src/backend/Makefile
 src/client/def/Makefile src/client/c/Makefile src/client/java/Makefile src/client/php/Makefile src/client/cs/Makefile
-src/client/perl/Makefile src/client/python/Makefile src/client/pascal/Makefile src/client/ruby/Makefile src/client/lua/Makefile
+src/client/perl/Makefile src/client/python/Makefile src/client/pascal/Makefile src/client/ruby/Makefile src/client/lua/Makefile src/client/go/Makefile
 src/tools/eibnet/Makefile src/tools/bcu/Makefile src/usb/Makefile src/tools/Makefile systemd/Makefile systemd/knxd.service systemd/knxd.socket
 rpm/Makefile rpm/knxd.spec
 )

--- a/src/client/Makefile.am
+++ b/src/client/Makefile.am
@@ -4,5 +4,5 @@ else
 BUILDJAVA = 
 endif
 
-SUBDIRS=def c $(BUILDJAVA) php perl cs python pascal ruby lua .
+SUBDIRS=def c $(BUILDJAVA) php perl cs python pascal ruby lua go .
 

--- a/src/client/go/Makefile.am
+++ b/src/client/go/Makefile.am
@@ -1,0 +1,26 @@
+CC = $(CC_FOR_BUILD)
+CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
+CFLAGS = $(CFLAGS_FOR_BUILD)
+LDFLAGS = $(LDFLAGS_FOR_BUILD)
+LIBS = $(LIBS_FOR_BUILD)
+EXEEXT = $(EXEEXT_FOR_BUILD)
+
+AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client
+
+EXTRA_DIST = io.inc
+CLEANFILES = gen.inc EIBConnection.go result.inc
+
+result.inc : $(top_srcdir)/src/common/eibloadresult.h
+	cat $<  |grep IMG_ |sed -e 's/#define \(IMG_[A-Z_0-9]\+\)  \+\([0-9]\+\)/const \1 = \2/g' > $@
+
+noinst_PROGRAMS = gen
+
+gen_SOURCES=gen.c arg.def def.def
+
+pkgdata_DATA = EIBConnection.go
+
+gen.inc : gen$(EXEEXT)
+	./$< > $@
+
+EIBConnection.go : io.inc gen.inc result.inc
+	cat $^ > $@

--- a/src/client/go/arg.def
+++ b/src/client/go/arg.def
@@ -1,0 +1,104 @@
+EIBC_LICENSE(
+/*
+    EIBD client library
+    Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    In addition to the permissions in the GNU General Public License, 
+    you may link the compiled version of this file into combinations
+    with other programs, and distribute those combinations without any 
+    restriction coming from the use of this file. (The General Public 
+    License restrictions do apply in other respects; for example, they 
+    cover modification of the file, and distribution when not linked into 
+    a combine executable.)
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+)
+
+#define KAGARG_NONE AGARG_NONE
+#define KAGARG_BOOL(name, args) printf(", "); AGARG_BOOL(name, args)
+#define KAGARG_UINT8(name, args) printf(", "); AGARG_UINT8 (name, args)
+#define KAGARG_UINT8a(name, args) printf(", "); AGARG_UINT8a (name, args)
+#define KAGARG_UINT8b(name, args) printf(", "); AGARG_UINT8b (name, args)
+#define KAGARG_UINT16(name, args) printf(", "); AGARG_UINT16 (name, args)
+#define KAGARG_OUTUINT8(name, args) printf(", "); AGARG_OUTUINT8 (name, args)
+#define KAGARG_OUTUINT8a(name, args) printf(", "); AGARG_OUTUINT8a (name, args)
+#define KAGARG_OUTUINT16(name, args) printf(", "); AGARG_OUTUINT16 (name, args)
+#define KAGARG_OUTINT16(name, args) printf(", "); AGARG_OUTINT16 (name, args)
+#define KAGARG_OUTUINT32(name, args) printf(", "); AGARG_OUTUINT32 (name, args)
+#define KAGARG_ADDR(name, args) printf(", "); AGARG_ADDR (name, args)
+#define KAGARG_OUTADDR(name, args) printf(", "); AGARG_OUTADDR (name, args)
+#define KAGARG_OUTADDRa(name, args) printf(", "); AGARG_OUTADDRa (name, args) 
+#define KAGARG_INBUF(name, args) printf(", "); AGARG_INBUF (name, args)
+#define KAGARG_OUTBUF(name, args) printf(", "); AGARG_OUTBUF (name, args)
+#define KAGARG_OUTBUF_LEN(name, args) printf(", "); AGARG_OUTBUF_LEN (name, args)
+#define KAGARG_KEY(name, args) printf(", "); AGARG_KEY (name, args)
+
+#define KALARG_NONE ALARG_NONE
+#define KALARG_BOOL(name, args) printf(", "); ALARG_BOOL (name, args)
+#define KALARG_UINT8(name, args) printf(", "); ALARG_UINT8 (name, args)
+#define KALARG_UINT8a(name, args) printf(", "); ALARG_UINT8a (name, args)
+#define KALARG_UINT8b(name, args) printf(", "); ALARG_UINT8b (name, args)
+#define KALARG_UINT16(name, args) printf(", "); ALARG_UINT16 (name, args)
+#define KALARG_OUTUINT8(name, args) printf(", "); ALARG_OUTUINT8 (name, args)
+#define KALARG_OUTUINT8a(name, args) printf(", "); ALARG_OUTUINT8a (name, args)
+#define KALARG_OUTUINT16(name, args) printf(", "); ALARG_OUTUINT16 (name, args)
+#define KALARG_OUTINT16(name, args) printf(", "); ALARG_OUTINT16 (name, args)
+#define KALARG_OUTUINT32(name, args) printf(", "); ALARG_OUTUINT32 (name, args)
+#define KALARG_ADDR(name, args) printf(", "); ALARG_ADDR (name, args)
+#define KALARG_OUTADDR(name, args) printf(", "); ALARG_OUTADDR (name, args)
+#define KALARG_OUTADDRa(name, args) printf(", "); ALARG_OUTADDRa (name, args)
+#define KALARG_INBUF(name, args) printf(", "); ALARG_INBUF (name, args)
+#define KALARG_OUTBUF(name, args) printf(", "); ALARG_OUTBUF (name, args)
+#define KALARG_OUTBUF_LEN(name, args) printf(", "); ALARG_OUTBUF_LEN (name, args)
+#define KALARG_KEY(name, args) printf(", "); ALARG_KEY (name, args)
+
+#define AGARG_NONE 
+#define AGARG_BOOL(name, args) printf("%s bool", #name);   KAG ## args
+#define AGARG_INBUF(name, args) printf("%s []byte", #name);  KAG ## args
+#define AGARG_OUTBUF(name, args) printf("%s []byte", #name);  KAG ## args
+#define AGARG_OUTBUF_LEN(name, args) printf("%s_len uint32, %s []byte", #name, #name); KAG ## args
+#define AGARG_OUTADDR(name, args) printf("%s *EIBAddr", #name);  KAG ## args
+#define AGARG_OUTADDRa(name, args) printf("%s *EIBAddr", #name);  KAG ## args
+#define AGARG_ADDR(name, args) printf("%s EIBAddr", #name);  KAG ## args
+#define AGARG_KEY(name, args) printf("%s []byte", #name);  KAG ## args
+#define AGARG_UINT8(name, args) printf("%s uint8", #name);  KAG ## args
+#define AGARG_UINT8a(name, args) printf("%s uint8", #name);  KAG ## args
+#define AGARG_UINT8b(name, args) printf("%s uint8", #name);  KAG ## args
+#define AGARG_UINT16(name, args) printf("%s uint16", #name);  KAG ## args
+#define AGARG_OUTUINT8(name, args) printf("%s *uint8", #name);  KAG ## args
+#define AGARG_OUTUINT8a(name, args) printf("%s *uint8", #name);  KAG ## args
+#define AGARG_OUTUINT16(name, args) printf("%s *uint16", #name);  KAG ## args
+#define AGARG_OUTINT16(name, args) printf("%s *uint16", #name);  KAG ## args
+#define AGARG_OUTUINT32(name, args) printf("%s *uint32", #name);  KAG ## args
+
+#define ALARG_NONE 
+#define ALARG_BOOL(name, args) printf("%s", #name);   KAL ## args
+#define ALARG_INBUF(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTBUF(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTBUF_LEN(name, args) printf("%s_len, %s", #name, #name);  KAL ## args
+#define ALARG_OUTADDR(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTADDRa(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_ADDR(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_KEY(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_UINT8(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_UINT8a(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_UINT8b(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_UINT16(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTUINT8(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTUINT8a(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTUINT16(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTINT16(name, args) printf("%s", #name);  KAL ## args
+#define ALARG_OUTUINT32(name, args) printf("%s", #name);  KAL ## args

--- a/src/client/go/def.def
+++ b/src/client/go/def.def
@@ -1,0 +1,227 @@
+/*
+    EIBD client library
+    Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    In addition to the permissions in the GNU General Public License, 
+    you may link the compiled version of this file into combinations
+    with other programs, and distribute those combinations without any 
+    restriction coming from the use of this file. (The General Public 
+    License restrictions do apply in other respects; for example, they 
+    cover modification of the file, and distribution when not linked into 
+    a combine executable.)
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#define EIBC_LICENSE(text)
+
+#define STR(A) #A
+#define SHORT2INT(h) "uint16(((this.data[" #h "])<<8)|(this.data[" #h "+1]))"
+#define SHORT2LONG(h) "uint32(((this.data[" #h "])<<24)|((this.data[" #h "+1])<<16)|((this.data[" #h "+2])<<8)|(this.data[" #h "+3]))"
+
+#define EIBTYPE (SHORT2INT(0))
+
+#define EIBC_GETREQUEST \
+	printf("    err := this.__EIB_GetRequest()\n"); \
+	printf("    if err != nil {\n"); \
+	printf("      return 0,err;\n"); \
+	printf("    }\n");
+
+#define EIBC_RETURNERROR(msg, error) \
+	printf("    if %s == %d {\n", EIBTYPE, msg); \
+	printf("      return 0,fmt.Errorf(\"%s\")\n", #error); \
+	printf("    }\n");
+
+#define EIBC_RETURNERROR_UINT16(offset, error) \
+	printf("    if %s == 0 {\n", SHORT2INT (offset)); \
+	printf("      return 0,fmt.Errorf(\"%s\")\n", #error); \
+	printf("    }\n");
+
+#define EIBC_RETURNERROR_SIZE(Length, error) \
+	printf("    if len(this.data) <= %d {\n", Length); \
+	printf("      return 0,fmt.Errorf(\"%s\")\n", #error); \
+	printf("    }\n");
+
+#define EIBC_CHECKRESULT(msg, msgsize) \
+	printf("    if %s != %d || len(this.data) < %d {\n", EIBTYPE, msg, msgsize); \
+	printf("      return 0,fmt.Errorf(\"ECONNRESET\")\n"); \
+	printf("    }\n");
+
+#define EIBC_RETURN_BUF(offset) \
+	printf("    return copy(this.buffer, this.data[%d:]),nil\n", offset); \
+
+#define EIBC_RETURN_OK \
+	printf("    return 0,nil\n");
+
+#define EIBC_RETURN_LEN \
+	printf("    return this.sendlen,nil\n");
+
+#define EIBC_RETURN_UINT8(offset) \
+	printf("    return int(this.data[%d]),nil\n", offset);
+
+#define EIBC_RETURN_UINT16(offset) \
+	printf("    return int(%s),nil\n", SHORT2INT (offset));
+
+#define EIBC_RETURN_PTR1(offset) \
+	printf("    if this.ptr1 != nil {\n"); \
+	printf("      *(this.ptr1) = %s\n", SHORT2INT (offset)); \
+	printf("    }\n");
+
+#define EIBC_RETURN_PTR2(offset) \
+	printf("    if this.ptr2 != nil {\n"); \
+	printf("      *(this.ptr2) = this.data[%d]\n", offset); \
+	printf("    }\n");
+
+#define EIBC_RETURN_PTR3(offset) \
+	printf("    if this.ptr3 != nil {\n"); \
+	printf("      *(this.ptr3) = this.data[%d]\n", offset); \
+	printf("    }\n");
+
+#define EIBC_RETURN_PTR4(offset) \
+	printf("    if this.ptr4 != nil {\n"); \
+	printf("      *(this.ptr4) = %s\n", SHORT2INT (offset)); \
+	printf("    }\n");
+
+#define EIBC_RETURN_PTR5(offset) \
+	printf("    if this.ptr5 != nil {\n"); \
+	printf("      *(this.ptr5) = %s\n", SHORT2INT (offset)); \
+	printf("    }\n");
+
+#define EIBC_RETURN_PTR6(offset) \
+	printf("    if this.ptr6 != nil {\n"); \
+	printf("      *(this.ptr6) = %s\n", SHORT2INT (offset)); \
+	printf("    }\n");
+
+#define EIBC_RETURN_PTR7(offset) \
+	printf("    if this.ptr7 != nil {\n"); \
+	printf("      *(this.ptr7) = %s\n", SHORT2LONG (offset)); \
+	printf("    }\n");
+
+#define EIBC_COMPLETE(name, body) \
+	printf("func (this *EIBConnection) __%s_Complete() (int,error) {\n", #name); \
+	printf("    this.__complete = nil\n"); \
+	body \
+	printf("}\n\n");
+
+#define EIBC_INIT_COMPLETE(name) \
+	printf("    this.__complete = this.__%s_Complete;\n", #name); \
+	printf("    return 0,nil\n");
+
+#define EIBC_INIT_SEND(length) \
+	printf("    ibuf := make([]byte,%d);\n", length); \
+	printf("    _ = ibuf\n"); // dirty trick as sometime this macro is called unnecessarily
+
+#define EIBC_SEND_BUF(name) EIBC_SEND_BUF_LEN (name, 0)
+
+#define EIBC_SEND_BUF_LEN(name, Length) \
+	printf("    if len(%s) < %d {\n", #name, Length); \
+	printf("      return 0,fmt.Errorf(\"EINVAL\")\n"); \
+	printf("    }\n"); \
+	printf("    this.sendlen = len(%s)\n", #name); \
+	printf("    ibuf = append(ibuf,%s...)\n", #name);
+
+#define EIBC_SEND_LEN(name) STR((len(name)))
+
+#define EIBC_SEND(msg) \
+	printf("    ibuf[%d] = %d\n", 0, ((msg>>8)&0xff)); \
+	printf("    ibuf[%d] = %d\n", 1, ((msg)&0xff)); \
+	printf("    err := this.__EIB_SendRequest(ibuf)\n"); \
+	printf("    if err != nil {\n"); \
+	printf("      return 0,err;\n"); \
+	printf("    }\n");
+
+#define EIBC_READ_BUF(buffer) \
+	printf("    this.buffer = %s\n", #buffer);
+
+
+#define EIBC_READ_LEN(name) STR(name ## _len)
+
+#define EIBC_PTR1(name) \
+	printf("    this.ptr1 = (*uint16)(%s)\n", #name);
+
+#define EIBC_PTR2(name) \
+	printf("    this.ptr2 = (*uint8)(%s)\n", #name);
+
+#define EIBC_PTR3(name) \
+	printf("    this.ptr3 = (*uint8)(%s)\n", #name);
+
+#define EIBC_PTR4(name) \
+	printf("    this.ptr4 = (*uint16)(%s)\n", #name);
+
+#define EIBC_PTR5(name) \
+	printf("    this.ptr5 = (*uint16)(%s)\n", #name);
+
+#define EIBC_PTR6(name) \
+	printf("    this.ptr6 = (*uint16)(%s)\n", #name);
+
+#define EIBC_PTR7(name) \
+	printf("    this.ptr7 = (*uint32)(%s)\n", #name);
+
+#define EIBC_SETADDR(name, offset) \
+	printf("    ibuf[%d] = byte((%s>>8)&0xff)\n", offset, #name); \
+	printf("    ibuf[%d] = byte((%s)&0xff)\n", offset+1, #name);
+
+#define EIBC_SETUINT8(name, offset) \
+	printf("    ibuf[%d] = byte((%s)&0xff)\n", offset, #name);
+
+#define EIBC_UINT8(name, offset) \
+	printf("    ibuf[%d] = byte((%s)&0xff)\n", offset, #name);
+
+#define EIBC_SETUINT16(name, offset) \
+	printf("    ibuf[%d] = byte((%s>>8)&0xff)\n", offset, #name); \
+	printf("    ibuf[%d] = byte((%s)&0xff)\n", offset+1, #name);
+
+#define EIBC_SETLEN(name, offset) \
+	printf("    ibuf[%d] = byte((%s>>8)&0xff)\n", offset, name); \
+	printf("    ibuf[%d] = byte((%s)&0xff)\n", offset+1, name);
+
+#define EIBC_SETBOOL(value, offset) \
+	printf("    if %s != false {\n", #value); \
+	printf("      ibuf[%d] = 0xff\n", offset); \
+	printf("    } else {\n"); \
+	printf("      ibuf[%d] = 0x00\n", offset); \
+	printf("    }\n"); \
+
+#define EIBC_SETKEY(value, offset) \
+	printf("    if len(%s) != 4 {\n", #value); \
+	printf("      return 0,fmt.Errorf(\"EINVAL\")\n"); \
+	printf("    }\n"); \
+	printf("    copy(ibuf[%d:%d], %s)\n", offset, offset+4, #value);
+
+#define EIBC_ASYNC(name, args, body) \
+	printf("func (this *EIBConnection) %s_async(", #name); \
+	AG ## args \
+	printf(") (int,error) {\n"); \
+	body \
+	printf("}\n\n"); \
+	printf("func (this *EIBConnection) %s(", #name); \
+	AG ## args \
+	printf(") (int,error) {\n"); \
+	printf ("    _,err := this.%s_async (", #name); \
+	AL ## args \
+	printf (")\n"); \
+	printf ("    if err != nil {\n"); \
+	printf ("      return 0,err\n"); \
+	printf ("    }\n"); \
+	printf ("    return this.EIBComplete ()"); \
+	printf("}\n\n");
+
+#define EIBC_SYNC(name, args, body) \
+	printf("func (this *EIBConnection) %s(", #name); \
+	AG ## args \
+	printf(") (int,error) {\n"); \
+	body \
+	printf("}\n\n");
+

--- a/src/client/go/gen.c
+++ b/src/client/go/gen.c
@@ -1,0 +1,38 @@
+/*
+    EIBD client library
+    Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    In addition to the permissions in the GNU General Public License, 
+    you may link the compiled version of this file into combinations
+    with other programs, and distribute those combinations without any 
+    restriction coming from the use of this file. (The General Public 
+    License restrictions do apply in other respects; for example, they 
+    cover modification of the file, and distribution when not linked into 
+    a combine executable.)
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <stdio.h>
+#include "eibtypes.h"
+#include "go/def.def"
+#include "go/arg.def"
+
+int
+main ()
+{
+#include "def/all.lst"
+  return 0;
+}

--- a/src/client/go/io.inc
+++ b/src/client/go/io.inc
@@ -1,0 +1,225 @@
+/* 
+     EIBD client library
+     Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+   
+     This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation; either version 2 of the License, or
+     (at your option) any later version.
+   
+     In addition to the permissions in the GNU General Public License, 
+     you may link the compiled version of this file into combinations
+     with other programs, and distribute those combinations without any 
+     restriction coming from the use of this file. (The General Public 
+     License restrictions do apply in other respects; for example, they 
+     cover modification of the file, and distribution when not linked into 
+     a combine executable.)
+   
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+   
+     You should have received a copy of the GNU General Public License
+     along with this program; if not, write to the Free Software
+     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/ 
+
+package eibd
+
+import (
+  "fmt"
+  "net"
+  "strconv"
+  "strings"
+  "time"
+)
+
+type CompleteFunc func() (int,error)
+
+type EIBAddr uint16
+
+type EIBConnection struct {
+    head       []byte
+    data       []byte
+    readlen    int
+    datalen    int
+    sendlen    int
+    con        net.Conn
+    buffer     []byte
+    __complete CompleteFunc
+    ptr1       *uint16
+    ptr2       *uint8
+    ptr3       *uint8
+    ptr4       *uint16
+    ptr5       *uint16
+    ptr6       *uint16
+    ptr7       *uint32
+}
+
+func NewEIBConnection() (*EIBConnection) {
+    return &EIBConnection{nil,nil,0,0,0,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil}
+}
+
+func (this *EIBConnection) EIBSocketLocal(path string) (error) {
+
+    if this.con != nil {
+      return fmt.Errorf("Connection already open")
+    }
+    var err error
+    this.con,err = net.Dial("unix", path)
+    if err != nil {
+      return err
+    }
+    this.data = nil
+    this.readlen = 0
+    return nil
+}
+
+func (this *EIBConnection) EIBSocketRemote(host string, port uint16) (error) {
+
+    if this.con != nil {
+      return fmt.Errorf("Connection already open")
+    }
+    var hostport string
+    fmt.Sprintf(hostport,"%s:%d",host,port)
+    var err error
+    this.con,err = net.Dial("tcp", hostport)
+    if err != nil {
+      return err
+    }
+    this.data = nil
+    this.readlen = 0
+    return nil
+}
+
+func (this *EIBConnection) EIBSocketURL(url string) (error) {
+
+    if url[0:6] == "local:" {
+      return this.EIBSocketLocal(url[6:])
+    }
+    if url[0:3] == "ip:" {
+         parts := strings.Split(url,":")
+         if len(parts) == 2 {
+             parts = append(parts,"6720")
+         }
+         port,err := strconv.Atoi(parts[2])
+         if err != nil || port<0 || port>65535 {
+            return fmt.Errorf("Port invalid")
+         }
+         return this.EIBSocketRemote(parts[1], uint16(port))
+    }
+    return fmt.Errorf("Protocol invalid")
+}
+
+func (this *EIBConnection) EIBComplete() (int,error) {
+    if this.__complete == nil {
+        return 0,fmt.Errorf("Already completed")
+    }
+    return this.__complete()
+}
+
+func (this *EIBConnection) EIBClose() (error) {
+    if this.con == nil {
+      return fmt.Errorf("Close failed, not connected")
+    }
+    this.con.Close()
+    this.con = nil
+    return nil
+}
+
+func (this *EIBConnection) EIBClose_sync() (error) {
+    this.EIBReset()
+    return this.EIBClose()
+}
+
+func (this *EIBConnection) __EIB_SendRequest(data []byte) (error) {
+    if this.con == nil {
+      return fmt.Errorf("Not connected")
+    }
+    if len(data) < 2 || len(data) > 0xffff {
+      return fmt.Errorf("Invalid data")
+    }
+    headdata := []byte{ byte((len(data)>>8)&0xff), byte((len(data))&0xff) }
+    data = append(headdata,data...)
+    _,err := this.con.Write(data) // TODO evtl evaluate n
+    return err
+}
+
+func (this *EIBConnection) EIB_Poll_FD() (int, error) {
+    if this.con == nil {
+      return 0,fmt.Errorf("Not connected")
+    }
+    return 0,fmt.Errorf("Not yet implemented") // TODO
+}
+
+func (this *EIBConnection) EIB_Poll_Complete() (bool,error) {
+    if this.__EIB_CheckRequest(false) != nil {
+      return false,fmt.Errorf("Request failed")
+    }
+    if this.readlen < 2 || (this.readlen >= 2 && this.readlen < this.datalen + 2) {
+      return false,nil
+    }
+    return true,nil
+}
+
+func (this *EIBConnection) __EIB_GetRequest() (error) {
+    for {
+        if this.__EIB_CheckRequest(true) != nil {
+            return fmt.Errorf("Request failed")
+        }
+        if this.readlen >= 2 && this.readlen >= this.datalen + 2 {
+            this.readlen = 0
+            return nil
+        }
+    }
+}
+
+func (this *EIBConnection) __EIB_CheckRequest(block bool) (error) {
+
+    if this.con == nil {
+      return fmt.Errorf("Not connected")
+    }
+
+    if this.readlen == 0 {
+      this.head = []byte{}
+      this.data = []byte{}
+    }
+    if this.readlen < 2 {
+      if block == true {
+        this.con.SetDeadline(time.Time{})
+      } else {
+        this.con.SetDeadline(time.Now().Add(1*time.Millisecond))
+      }
+      buf := make([]byte, 2-this.readlen)
+      n,err := this.con.Read (buf)
+      this.con.SetDeadline(time.Time{}) // reset the absolute deadline
+      if err != nil {
+        return err
+      }
+      this.head = append(this.head,buf...)
+      this.readlen += n
+    }
+    if this.readlen < 2 {
+      return nil
+    }
+    this.datalen = int( (this.head[0] << 8) | this.head[1] )
+    if this.readlen < this.datalen + 2 {
+      if block == true {
+        this.con.SetDeadline(time.Time{})
+      } else {
+        this.con.SetDeadline(time.Now().Add(1*time.Millisecond))
+      }
+      buf := make([]byte, this.datalen + 2-this.readlen)
+      n,err := this.con.Read (buf)
+      this.con.SetDeadline(time.Time{}) // reset the absolute deadline
+      if err != nil {
+        return err
+      }
+      this.data = append(this.data,buf...)
+      this.readlen += n
+    }
+    return nil
+}
+
+

--- a/src/client/go/io.inc
+++ b/src/client/go/io.inc
@@ -35,6 +35,63 @@ import (
   "time"
 )
 
+
+type DevAddr EIBAddr
+
+func DevAddrFromString(addr string) (DevAddr,error) {
+  var a,b,c uint8
+  if n,err := fmt.Sscanf(addr, "%d.%d.%d", &a, &b, &c); n<3 {
+    return 0,err
+  }
+  return (DevAddr(a&0x0f)<<12) | (DevAddr(b&0x0f)<<8) | DevAddr(c&0xff),nil
+}
+
+func (addr DevAddr) String() string {
+  return fmt.Sprintf("%d.%d.%d", uint8(addr>>12)&0x0F,
+                                 uint8(addr>>8)&0x0F,
+                                 uint8(addr)&0xFF)
+}
+
+
+
+type GroupAddr EIBAddr
+
+func GroupAddrFromString(addr string) (GroupAddr,error) {
+  var a,b,c uint
+  var af,bf,cf GroupAddr
+  n,_ := fmt.Sscanf(addr, "%d/%d/%d", &a, &b, &c)
+
+  if n == 3 && a <= 0x1F && b <= 0x07 && c <= 0xFF {
+    af = GroupAddr(a)
+    bf = GroupAddr(b)
+    cf = GroupAddr(c)
+    return (af<<11) | (bf<<8) | cf, nil
+  }
+  if n == 2 && a <= 0x1F && b <= 0x7FF {
+    af = GroupAddr(a)
+    bf = GroupAddr((b>>8)&0x07)
+    cf = GroupAddr(b&0xFF)
+    return (af<<11) | (bf<<8) | cf, nil
+  }
+
+  n,_ = fmt.Sscanf (addr, "%x", &a)
+  if n == 1 && a <= 0xFFFF {
+    af = GroupAddr((a>>11)&0x1F)
+    bf = GroupAddr((a>>8)&0x07)
+    cf = GroupAddr(a&0xFF)
+    return (af<<11) | (bf<<8) | cf, nil
+  }
+
+  return 0,fmt.Errorf("Invalid Group Address")
+}
+
+func (addr GroupAddr) String() string {
+  return fmt.Sprintf("%d/%d/%d", uint8(addr>>11)&0x1F,
+                                 uint8(addr>>8)&0x07,
+                                 uint8(addr)&0xFF)
+}
+
+
 type CompleteFunc func() (int,error)
 
 type EIBAddr uint16


### PR DESCRIPTION
I added client language bindings for Google Go (alias golang). The first commit are the pure bindings, in the second commit I added some functions that are helpful when using the bindings.

I decided to follow the Go convention to return the error code as second return parameter rather than using a global errno variable as for example the python binding does.

To use the binding the EIBConnection.go needs to be copied to the $GOPATH, e.g. to $GOPATH/src/eibd/
Here [knxd_sample.go](https://github.com/knxd/knxd/files/721383/knxd_sample.go.txt) is a working example code how to use it in go.