### PR TITLE
FT1.2 / EMI2 robustness

### DIFF
--- a/src/backend/ft12.cpp
+++ b/src/backend/ft12.cpp
@@ -326,8 +326,12 @@ FT12wrap::process_read(bool is_timeout)
                   t->TracePacket (0, "RecvReset", c);
                   LowLevelFilter::recv_Data (c);
                 }
+              akt.deletepart (0, 4);
             }
-          akt.deletepart (0, 4);
+          else
+            {
+              akt.deletepart (0, 1);
+            }
         }
       else if (akt[0] == 0x68)
         {
@@ -337,6 +341,7 @@ FT12wrap::process_read(bool is_timeout)
             break;
           if (akt[1] != akt[2] || akt[3] != 0x68)
             {
+              akt.deletepart (0, 1);
               //receive error, try to resume
               goto err_out;
             }
@@ -378,14 +383,16 @@ FT12wrap::process_read(bool is_timeout)
           akt.deletepart (0, len);
         }
       else
-        /* if timeout OR an unknown byte, drop it. */
-        if (false)
-          {
-    err_out:
-            if (!is_timeout)
-              break;
-          }
-        akt.deletepart (0, 1);
+        {
+          /* if timeout OR an unknown byte, drop it. */
+          if (false)
+            {
+      err_out:
+              if (!is_timeout)
+                break;
+            }
+          akt.deletepart (0, 1);
+        }
     }
 
   if (akt.size())

--- a/src/libserver/eibnetip.cpp
+++ b/src/libserver/eibnetip.cpp
@@ -188,7 +188,7 @@ EIBNetIPSocket::EIBNetIPSocket (struct sockaddr_in bindaddr, bool reuseaddr,
   else
     io_recv.start(fd, ev::READ);
 
-  TRACEPRINTF (t, 0, "Openend");
+  TRACEPRINTF (t, 0, "Opened");
 }
 
 EIBNetIPSocket::~EIBNetIPSocket ()

--- a/src/libserver/emi2.cpp
+++ b/src/libserver/emi2.cpp
@@ -89,6 +89,31 @@ EMI2Driver::cmdClose ()
   send_Local (CArray (t, sizeof (t)),1);
 }
 
+void EMI2Driver::started()
+{
+  reset_ack_wait = true;
+  reset_timer.start(0.5, 0);
+  sendReset();
+}
+
+void EMI2Driver::reset_timer_cb(ev::timer& w, int revents)
+{
+  ERRORPRINTF(t, E_ERROR, "reset timed out");
+  errored();
+}
+
+void EMI2Driver::do_send_Next()
+{
+  if (reset_ack_wait)
+  {
+    reset_ack_wait = false;
+    reset_timer.stop();
+    EMI_Common::started();
+  }
+  else
+    EMI_Common::do_send_Next();
+}
+
 const uint8_t *
 EMI2Driver::getIndTypes()
 {

--- a/src/libserver/emi2.h
+++ b/src/libserver/emi2.h
@@ -25,17 +25,23 @@
 /** EMI2 backend */
 class EMI2Driver:public EMI_Common
 {
+  bool reset_ack_wait = false;
+  ev::timer reset_timer;
+
   void cmdEnterMonitor();
   void cmdLeaveMonitor();
   void cmdOpen();
   void cmdClose();
+  void started(); // do sendReset
   const uint8_t * getIndTypes();
   EMIVer getVersion() { return vEMI2; }
   void sendLocal_done_cb(bool success);
+  void reset_timer_cb(ev::timer& w, int revents);
   enum { N_bad, N_up, N_down, N_open, N_enter } sendLocal_done_next = N_bad;
 public:
   EMI2Driver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i = nullptr);
   virtual ~EMI2Driver ();
+  void do_send_Next();
 };
 
 #endif

--- a/src/libserver/llserial.cpp
+++ b/src/libserver/llserial.cpp
@@ -129,7 +129,7 @@ LLserial::start()
       goto ex3;
     }
 
-  TRACEPRINTF (t, 2, "Openend");
+  TRACEPRINTF (t, 2, "Opened");
   FDdriver::start();
   return;
 

--- a/src/libserver/lltcp.cpp
+++ b/src/libserver/lltcp.cpp
@@ -82,7 +82,7 @@ LLtcp::start()
   setsockopt (fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof (reuse));
   setsockopt (fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof (nodelay));
 
-  TRACEPRINTF (t, 2, "Openend");
+  TRACEPRINTF (t, 2, "Opened");
   FDdriver::start();
   return;
 


### PR DESCRIPTION
While doing some testing primarily with fhem and ETS5, I found a few issues that stopped knxd quickly especially with high bus load. These patches address the things found so far.

With these patches, I can do quick un-throttled group scans on fhem startup (ok, ~20 groups only in my network ;-) and both ETS5 line scan and device read-out.