### PR TITLE
Changed the order of the command_args an put some space in it

### DIFF
--- a/contrib/gentoo/sys-apps/knxd/files/knxd.init
+++ b/contrib/gentoo/sys-apps/knxd/files/knxd.init
@@ -6,7 +6,7 @@
 
 pidfile="/run/knxd/knxd-@SLOT@.pid"
 command="/usr/bin/knxd"
-command_args="--pid-file=${pidfile} -d ${KNXD_LOGFILE} ${KNXD_OPTS}"
+command_args="--pid-file=${pidfile} --daemon=${KNXD_LOGFILE} ${KNXD_OPTS}"
 start_stop_daemon_args="-u ${KNXD_USER}"
 description="Daemon for accessing the EIB/KNX bus"
 

--- a/contrib/gentoo/sys-apps/knxd/files/knxd.init
+++ b/contrib/gentoo/sys-apps/knxd/files/knxd.init
@@ -6,7 +6,7 @@
 
 pidfile="/run/knxd/knxd-@SLOT@.pid"
 command="/usr/bin/knxd"
-command_args="${KNXD_OPTS} --pid-file=${pidfile} -d${KNXD_LOGFILE}"
+command_args="--pid-file=${pidfile} -d ${KNXD_LOGFILE} ${KNXD_OPTS}"
 start_stop_daemon_args="-u ${KNXD_USER}"
 description="Daemon for accessing the EIB/KNX bus"
 


### PR DESCRIPTION
'-d/some/file' isn't working but '-d /some/file' does, so this is
a workaround. Also global options should come first.

This was discussed here [#277](https://github.com/knxd/knxd/pull/277)