### PR TITLE
BUGFIX: fixed segfault at exit, when usb setup failed

### DIFF
--- a/src/libserver/eibusb.cpp
+++ b/src/libserver/eibusb.cpp
@@ -372,6 +372,7 @@ USBDriver::setup ()
   return true;
 ex1:
   delete iface;
+  iface = nullptr;
   return false;
 }
 


### PR DESCRIPTION
I've got an annoying list of segfaults in my log, when the usb interface isn't plugged in. So here is a little fix.