### PR TITLE
Update dependencies in knxd.service.in

### DIFF
--- a/systemd/knxd.service.in
+++ b/systemd/knxd.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=KNX Daemon
+Requires=network-online.target
 After=network.target knxd.socket
 
 [Service]

--- a/systemd/knxd.service.in
+++ b/systemd/knxd.service.in
@@ -1,6 +1,5 @@
 [Unit]
 Description=KNX Daemon
-Requires=network-online.target
 After=network.target knxd.socket
 
 [Service]
@@ -14,5 +13,5 @@ Restart=on-failure
 RestartSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target network-online.target
 Also=knxd.socket


### PR DESCRIPTION
To ensure the network is up and running the dependency After=network.target is not sufficient. knxd fails if it is configured as router and the multicast address isn't set yet. Added property  Requires=network-online.target which ensures a "configured, routable IP address of some kind". Reference https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/