### PR TITLE
increased default timeout and retry count for older usb interfaces

### DIFF
--- a/src/libserver/emi_common.cpp
+++ b/src/libserver/emi_common.cpp
@@ -60,8 +60,8 @@ EMI_Common::setup()
     return false;
   if(!LowLevelFilter::setup())
     return false;
-  send_timeout = cfg->value("send-timeout",300) / 1000.;
-  max_retries = cfg->value("send-retries",3);
+  send_timeout = cfg->value("send-timeout",6000) / 1000.;
+  max_retries = cfg->value("send-retries",5);
   monitor = cfg->value("monitor",false);
 
   return true;


### PR DESCRIPTION
my usb/knx interface sends data and confirmation callback slower then timeout , this is the fix