### PR TITLE
Fix for tpuart: on resending frame the checksum needs to be recalculated

### DIFF
--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -218,6 +218,15 @@ TPUARTwrap::send_again()
 
       // clear retry flag. for later comparison
       out[0] &=~ 0x20;
+
+      //recalc checksum
+      z = out.size() -1;
+      out[z] = out[0];
+      for (i = 1; i < z; i++)
+      {
+          out[z] ^= out[i];
+      }
+      out[z] = ~out[z];
     }
 }
 


### PR DESCRIPTION
knxd is running on Banana-Pi with Busware TPUART Head together with the smarthome.py project.
After adding some new knx-nodes with no corosponding groupaddress on the bus in the smarthome.py starts killing the knxd
As those frames to unkonwn addresses got no ack, they will be retransmitted by knxd.
The repeat-flag is cleard - but the checksum is not recalculated!

therefore all tries to resend the frame will get the error response 0x47 ( parity / bit / checksum error)
as knxd has no chance to get out of this loop, it will die after some retries...

with this fix knxd runs stable here...