### PR TITLE
If knxd is compiled without systemd support command line options parsed incorrectly

### DIFF
--- a/src/common/inifile.cpp
+++ b/src/common/inifile.cpp
@@ -60,7 +60,11 @@ IniSection::value(const std::string& name, const std::string& def)
 const std::string
 IniSection::value(const std::string& name, const char *def)
 {
-  std::string s = def;
+  std::string s="";  
+  if(def)
+  {
+     s=value(name,std::string(def));
+  }
   return value(name,s);
 }
 


### PR DESCRIPTION
When knxd is compiled without systemd support some command line options (pidfile, logfile) are parsed incorrectly, because IniSection::value(const std::string& name, const char *def) always returns *def even if a value in section exists. Solution is to call IniSection::value(const std::string& name, const std::string& def) from IniSection::value(const std::string& name, const char *def)