### PR TITLE
When knxd is compiled without systemd support pidfile and logfile not set correctly

### DIFF
--- a/src/server/knxd.cpp
+++ b/src/server/knxd.cpp
@@ -333,8 +333,10 @@ main (int ac, char *ag[])
     die("Parse error of '%s' in line %d", cfgfile, errl);
   IniSectionPtr main = i[mainsection];
 
-  pidfile = using_systemd ? NULL : main->value("pidfile","").c_str();
-  logfile = using_systemd ? NULL : main->value("logfile","").c_str();
+  std::string PidFile=main->value("pidfile","");
+  pidfile = using_systemd ? NULL : PidFile.c_str(); 
+  std::string Logfile=main->value("logfile","");
+  logfile = using_systemd ? NULL : Logfile.c_str(); 
   background = using_systemd ? false : main->value("background",false);
 
   if (!stop_now)

--- a/src/server/knxd.cpp
+++ b/src/server/knxd.cpp
@@ -40,8 +40,8 @@ bool stop_now = false;
 bool do_list = false;
 bool background = false;
 bool stopping = false;
-const char *pidfile = NULL;
-const char *logfile = NULL;
+char *pidfile = NULL;
+char *logfile = NULL;
 const char *cfgfile = NULL;
 const char *mainsection = NULL;
 char *const *argv;
@@ -333,11 +333,23 @@ main (int ac, char *ag[])
     die("Parse error of '%s' in line %d", cfgfile, errl);
   IniSectionPtr main = i[mainsection];
 
-  std::string PidFile=main->value("pidfile","");
-  pidfile = using_systemd ? NULL : PidFile.c_str(); 
-  std::string Logfile=main->value("logfile","");
-  logfile = using_systemd ? NULL : Logfile.c_str(); 
-  background = using_systemd ? false : main->value("background",false);
+  if(!using_systemd)
+  {
+
+      std::string PidFile = main->value("pidfile","");
+      
+      pidfile = new char[ PidFile.length()+1 ];
+      strncpy(pidfile, PidFile.c_str(), PidFile.length());
+      pidfile[ PidFile.length() ] = '\0';
+
+      std::string LogFile = main->value("logfile","");
+      
+      logfile = new char[ LogFile.length()+1 ];
+      strncpy(logfile, LogFile.c_str(),LogFile.length());
+      logfile[ LogFile.length() ] = '\0';
+
+      background=main->value("background",false);
+  }
 
   if (!stop_now)
     stop_now = main->value("stop-after-setup",false);


### PR DESCRIPTION
When knxd is compiled without systemd support and the command line options -p /run/pidfile  and -d /some/logfilename are set, the variables pidfile and logfile in knxd.cpp are always empty. The Method main->value(..).c_str() does return the value for the requested parameters correctly but is only available as long as the method is running. After the method has finshed the length of the *char (pidfile, logfile) variable set by c_str() is 0. Solution is to store the return value as a std::string.
Finally got it work after 3 tries :-) May be not the best implementation but working.