### PR TITLE
Fixed misspelled HAVE_TPUART

### DIFF
--- a/src/libserver/llserial.cpp
+++ b/src/libserver/llserial.cpp
@@ -25,7 +25,7 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <termios.h>
-#ifdef HAVE_LINUX_LOWLATENCY
+#ifdef HAVE_LINUX_LOWLATENCY___DO___NOT___USE
 #include <sys/ioctl.h>
 #include <string.h> // memcpy
 #endif

--- a/src/libserver/lowlatency.cpp
+++ b/src/libserver/lowlatency.cpp
@@ -29,7 +29,7 @@ set_low_latency (int fd, low_latency_save * save)
 {
   struct termios opts;
 
-#ifdef HAVE_LINUX_LOWLATENCY
+#ifdef HAVE_LINUX_LOWLATENCY___DO___NOT___USE
   struct serial_struct snew;
   ioctl (fd, TIOCGSERIAL, &save->ser);
   memcpy(&snew, &save->ser, sizeof(snew));
@@ -54,7 +54,7 @@ set_low_latency (int fd, low_latency_save * save)
 void
 restore_low_latency (int fd, low_latency_save * save)
 {
-#ifdef HAVE_LINUX_LOWLATENCY
+#ifdef HAVE_LINUX_LOWLATENCY___DO___NOT___USE
   ioctl (fd, TIOCSSERIAL, &save->ser);
 #endif
   ioctl (fd, TCSANOW, &save->term);

--- a/src/libserver/lowlatency.h
+++ b/src/libserver/lowlatency.h
@@ -23,13 +23,13 @@
 #include "config.h"
 
 #include <termios.h>
-#ifdef HAVE_LINUX_LOWLATENCY
+#ifdef HAVE_LINUX_LOWLATENCY___DO___NOT___USE
 #include <linux/serial.h>
 #endif
 
 typedef struct {
 	struct termios term;
-#ifdef HAVE_LINUX_LOWLATENCY
+#ifdef HAVE_LINUX_LOWLATENCY___DO___NOT___USE
 	serial_struct ser;
 #endif
 } low_latency_save;

--- a/src/server/knxd_args.cpp
+++ b/src/server/knxd_args.cpp
@@ -390,7 +390,7 @@ static struct argp_option options[] = {
   {"no-tunnel-client-queuing", OPT_BACK_TUNNEL_NOQUEUE, 0, 0,
    "wait 30msec between transmitting packets. Obsolete, please use --send-delay=30"},
 #endif
-#if defined(HAVE_TPUARTs) || defined(HAVE_TPUARTs_TCP)
+#if defined(HAVE_TPUART) || defined(HAVE_TPUARTs_TCP)
   {"tpuarts-ack-all-group", OPT_BACK_TPUARTS_ACKGROUP, 0, 0,
    "tpuarts backend should generate L2 acks for all group telegrams"},
   {"tpuarts-ack-all-individual", OPT_BACK_TPUARTS_ACKINDIVIDUAL, 0, 0,


### PR DESCRIPTION
Fixed misspelled HAVE_TPUART (was HAVE_TPUARTs in knxd_args.cpp, but HAVE_TPUART in configure.ac)