### PR TITLE
Make eibread-cgi return just the requested values, and in timely manner

### DIFF
--- a/src/libserver/groupcache.cpp
+++ b/src/libserver/groupcache.cpp
@@ -100,7 +100,7 @@ GroupCache::send_L_Data (LDataPtr l)
               c->second.src = l->source;
               c->second.data = t1->data;
               c->second.recvtime = time (0);
-              c->second.seq = ++seq;
+              c->second.seq = seq++;
               cache_seq.emplace(c->second.seq,c->first);
               updated(c->second);
 	    }

--- a/src/libserver/groupcache.cpp
+++ b/src/libserver/groupcache.cpp
@@ -318,6 +318,8 @@ public:
     this->start = start;
     timeout.set<GCTracker,&GCTracker::timeout_cb>(this);
     timeout.start(Timeout,0);
+    if (start != gc->seq)
+      handler();
   }
   virtual ~GCTracker() {
       a.clear();

--- a/src/libserver/groupcache.cpp
+++ b/src/libserver/groupcache.cpp
@@ -374,8 +374,7 @@ GroupCache::LastUpdates (uint16_t start, uint8_t Timeout,
   st = (seq&~0xFFFF) + start;
   if (st > seq)
     st -= 0x10000;
-  else
-    new GCTracker(this, st, Timeout, cb,cc);
+  new GCTracker(this, st, Timeout, cb,cc);
 }
 
 void

--- a/src/tools/eibread-cgi.c
+++ b/src/tools/eibread-cgi.c
@@ -352,7 +352,7 @@ main ()
           continue;
         seenGA[dest>>3] |= 1<<((dest&7));
 
-        if ((subscribedGA[dest>>3]&(1<<((dest&7)))) || (subscribedGA[0] | 1))
+        if ((subscribedGA[dest>>3]&(1<<((dest&7)))) || (subscribedGA[0] & 1))
         {
           // read value from cache
           len_gread = EIB_Cache_Read (con, dest, &src, sizeof(buf_gread), buf_gread);

--- a/src/tools/eibread-cgi.c
+++ b/src/tools/eibread-cgi.c
@@ -296,6 +296,8 @@ main ()
   strcpy(outptr,"{\"d\": {");
   outptr += strlen(outptr);
 
+  memset(seenGA,0,sizeof(seenGA));
+
   if (lastpos==0 ) //initial read
   {
     for (i = 1; i < UINT16; i++) // skip all-zero GA
@@ -336,8 +338,6 @@ main ()
       }
     }
   }
-
-  memset(seenGA,0,sizeof(seenGA));
 
   while ((!seen || lastpos <1) && difftime(time(NULL), tstart) < timeout) {
     len = EIB_Cache_LastUpdates2 (con, lastpos, timeout, sizeof (buf), buf, &lastpos);
@@ -385,9 +385,8 @@ main ()
           }
         }
       }
-    if (outptr != outbuf)
-      printf ("%s},\"i\":%d}\n",outbuf,lastpos);
   }
+  printf ("%s},\"i\":%d}\n",outbuf,lastpos);
   EIBClose (con);
   return 0;
 }


### PR DESCRIPTION
There were a few things I discovered while reviewing the underlying code that affects issue #352:
- Unrequested data was included in the answer (as mentioned by @grzlhmpf).
- It always waited for the timeout to trigger or new data to arrive before sending out updates, even if there were already data changes available.
- If it encountered a timeout without any value changes it included the last change in the answer again and again.
- The LastUpdates (16 bit) rollover implementation did not enumerate anything in the rollover case.

This should (mostly) fix #352.