### PR TITLE
build on macOS

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,13 @@ if test -f /usr/local/lib/libeibclient.so.0 ; then
 	echo "*** Remove them before building or installing knxd." >&2
 	exit 1
 fi
-libtoolize --copy --force --install && \
+case `uname` in
+	Darwin*)
+		LIBTOOLIZE=glibtoolize ;;
+	*)
+		LIBTOOLIZE=libtoolize ;;
+esac
+$LIBTOOLIZE --copy --force --install && \
 	aclocal -I m4 --force && \
 	autoheader && \
 	automake --add-missing --copy --force-missing && \

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ dnl ##    SUCH DAMAGE.
 
 AC_PREREQ(2.59)
 
-AC_INIT(knxd, m4_esyscmd(sh ./tools/version.sh))
+AC_INIT(knxd, m4_esyscmd(sh -c "./tools/version.sh | tr -d '\n'"))
 AM_INIT_AUTOMAKE([foreign])
 
 AC_CANONICAL_HOST


### PR DESCRIPTION
There is one more thing needed, but not sure how to make that OS independent: The linker on macOS does not support `--whole-archive` or `--no-whole-archive` - I don't know why those options are in use for the server code in the first place, maybe this can be removed for all OS? What's an acceptable way to modify .am files based on environment? Anyways this patch would be required to make it compile on macOS:

```diff
diff --git a/src/server/Makefile.am b/src/server/Makefile.am
index c51f98e..5fbf3de 100644
--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -3,7 +3,7 @@ libexec_PROGRAMS = knxd_args

 AM_CPPFLAGS=-I$(top_srcdir)/src/libserver -I$(top_srcdir)/src/backend -I$(top_srcdir)/src/common -I$(top_srcdir)/src/usb $(LIBUSB_CFLAGS) $(SYSTEMD_CFLAGS) -Wno-missing-field-initializers
 knxd_CPPFLAGS=$(AM_CPPFLAGS) -DLIBEXECDIR="\"$(libexecdir)\""
-knxd_LDFLAGS=-Wl,--whole-archive,../backend/libbackend.a,../libserver/libserver.a,--no-whole-archive
+knxd_LDFLAGS=-Wl,../backend/libbackend.a,../libserver/libserver.a
 knxd_LDADD=../libserver/libeibstack.a ../common/libcommon.a ../usb/libusb.a $(LIBUSB_LIBS) $(SYSTEMD_LIBS) $(EV_LIBS)
 knxd_DEPENDENCIES=../libserver/libserver.a ../backend/libbackend.a ../libserver/libeibstack.a ../common/libcommon.a ../usb/libusb.a
 knxd_args_DEPENDENCIES=../common/libcommon.a
```