### PR TITLE
Drop legacy Array and use std::vector instead

### DIFF
--- a/src/backend/nat.h
+++ b/src/backend/nat.h
@@ -36,7 +36,7 @@ FILTER(NatL2Filter,single)
   /** Fakes local source addresses so that knxd appears as a single KNX
    * device to the remote side */
 protected:
-  Array < phys_comm > revaddr; // TODO: replace with a map
+  std::vector < phys_comm > revaddr; // TODO: replace with a map
 
 public:
   eibaddr_t addr;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -137,7 +137,7 @@ class STR_ListParameter:public STR_Stream
 public:
   uint16_t addr;
   String name;
-    Array < String > elements;
+    std::vector < String > elements;
 
     STR_ListParameter ();
   bool init (const CArray & str);
@@ -277,7 +277,7 @@ class STR_BCU2Key:public STR_Stream
 {
 public:
   eibkey_type installkey;
-  Array < eibkey_type > keys;
+  std::vector < eibkey_type > keys;
 
   STR_BCU2Key ();
   bool init (const CArray & str);
@@ -292,7 +292,7 @@ public:
 class Image
 {
 public:
-  Array < STR_Stream * >str;
+  std::vector < STR_Stream * >str;
 
   Image ();
   virtual ~Image ();

--- a/src/common/loadimage.cpp
+++ b/src/common/loadimage.cpp
@@ -43,7 +43,7 @@ typedef struct
 } Segment;
 
 static int
-AddSegmentOverlap (Array < Segment > &s, uint16_t start, uint16_t len)
+AddSegmentOverlap (std::vector < Segment > &s, uint16_t start, uint16_t len)
 {
   unsigned int i;
   if (!len)
@@ -66,7 +66,7 @@ AddSegmentOverlap (Array < Segment > &s, uint16_t start, uint16_t len)
 BCU_LOAD_RESULT
 PrepareLoadImage (const CArray & im, BCUImage * &img)
 {
-  Array < Segment > seg;
+  std::vector < Segment > seg;
   img = 0;
   Image *i = Image::fromArray (im);
   if (!i)

--- a/src/common/loadimage.h
+++ b/src/common/loadimage.h
@@ -44,10 +44,10 @@ public:
     B_bcu1, B_bcu20, B_bcu21
   } BCUType;
   CArray code;
-  Array < EIBLoadRequest > load;
+  std::vector < EIBLoadRequest > load;
   eibaddr_t addr;
   eibkey_type installkey;
-  Array < eibkey_type > keys;
+  std::vector < eibkey_type > keys;
 };
 
 BCU_LOAD_RESULT PrepareLoadImage (const CArray & c, BCUImage * &img);

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -51,9 +51,6 @@ typedef std::string String;
 #define ITER(_i,_t) for(decltype(_t)::iterator _i = _t.begin(); _i != _t.end(); _i++)
 #define R_ITER(_i,_t) for(decltype(_t)::reverse_iterator _i = _t.rbegin(); _i != _t.rend(); _i++)
 
-/** generic arrays don't need any new code */
-#define Array std::vector
-
 /** byte arrays however need some help.
   We can't use strings: strings can't contain null characters.
   */

--- a/src/libserver/eibnetip.h
+++ b/src/libserver/eibnetip.h
@@ -280,7 +280,7 @@ public:
   eibaddr_t individual_addr;
   uint16_t installid;
   serialnumber_t serial;
-  Array < DIB_service_Entry > services;
+  std::vector < DIB_service_Entry > services;
   struct in_addr multicastaddr;
   uchar MAC[6];
   uchar name[30];
@@ -312,7 +312,7 @@ public:
   eibaddr_t individual_addr;
   uint16_t installid;
   serialnumber_t serial;
-  Array < DIB_service_Entry > services;
+  std::vector < DIB_service_Entry > services;
   struct in_addr multicastaddr;
   uchar MAC[6];
   uchar name[30];

--- a/src/libserver/eibnetserver.h
+++ b/src/libserver/eibnetserver.h
@@ -132,7 +132,7 @@ SERVER(EIBnetServer,ets_router)
   IniSectionPtr router_cfg;
   IniSectionPtr tunnel_cfg;
 
-  Array < ConnStatePtr > connections;
+  std::vector < ConnStatePtr > connections;
   Queue < ConnStatePtr > drop_q;
 
   int addClient (ConnType type, const EIBnet_ConnectRequest & r1,

--- a/src/libserver/groupcache.cpp
+++ b/src/libserver/groupcache.cpp
@@ -305,7 +305,7 @@ class GCTracker : protected GroupCacheReader
   GCLastCallback cb;
   ClientConnPtr cc;
   ev::timer timeout;
-  Array < eibaddr_t > a;
+  std::vector < eibaddr_t > a;
   uint32_t start;
 public:
   bool stopped = false;

--- a/src/libserver/groupcache.h
+++ b/src/libserver/groupcache.h
@@ -46,7 +46,7 @@ struct GroupCacheEntry
 };
 
 typedef void (*GCReadCallback)(const GroupCacheEntry &foo, bool nowait, ClientConnPtr c);
-typedef void (*GCLastCallback)(const Array<eibaddr_t> &foo, uint32_t end, ClientConnPtr c);
+typedef void (*GCLastCallback)(const std::vector<eibaddr_t> &foo, uint32_t end, ClientConnPtr c);
 
 class GroupCacheReader
 {
@@ -68,7 +68,7 @@ typedef std::unordered_map<eibaddr_t, GroupCacheEntry> CacheMap;
 
 class GroupCache:public Driver
 {
-  Array < GroupCacheReader * > reader;
+  std::vector < GroupCacheReader * > reader;
   /** The Cache */
   CacheMap cache;
   /** controlled by .Start/Stop; if false, the whole code does nothing */

--- a/src/libserver/groupcacheclient.cpp
+++ b/src/libserver/groupcacheclient.cpp
@@ -55,7 +55,7 @@ ReadCallback(const GroupCacheEntry &gce, bool nowait, ClientConnPtr c)
 }
 
 void
-LastUpdatesCallback(const Array<eibaddr_t> &addrs, uint32_t end, ClientConnPtr c)
+LastUpdatesCallback(const std::vector<eibaddr_t> &addrs, uint32_t end, ClientConnPtr c)
 {
   CArray erg;
 
@@ -72,7 +72,7 @@ LastUpdatesCallback(const Array<eibaddr_t> &addrs, uint32_t end, ClientConnPtr c
 }
 
 void
-LastUpdates2Callback(const Array<eibaddr_t> &addrs, uint32_t end, ClientConnPtr c)
+LastUpdates2Callback(const std::vector<eibaddr_t> &addrs, uint32_t end, ClientConnPtr c)
 {
   CArray erg;
 

--- a/src/libserver/layer7.cpp
+++ b/src/libserver/layer7.cpp
@@ -51,10 +51,10 @@ Layer7_Broadcast::A_IndividualAddress_Write (eibaddr_t addr)
   l4->recv (a.ToPacket ());
 }
 
-Array < eibaddr_t >
+std::vector < eibaddr_t >
   Layer7_Broadcast::A_IndividualAddress_Read (TracePtr tr, unsigned timeout)
 {
-  Array < eibaddr_t > addrs;
+  std::vector < eibaddr_t > addrs;
   A_IndividualAddress_Read_PDU r;
   APDUPtr a;
   l4->recv (r.ToPacket ());

--- a/src/libserver/layer7.h
+++ b/src/libserver/layer7.h
@@ -39,7 +39,7 @@ public:
   /** send IndividualAddress_Write */
   void A_IndividualAddress_Write (eibaddr_t addr);
   /** sends A_IndividualAddress_Read and collects responses */
-  Array < eibaddr_t > A_IndividualAddress_Read (TracePtr t, unsigned timeout = 3);
+  std::vector < eibaddr_t > A_IndividualAddress_Read (TracePtr t, unsigned timeout = 3);
 };
 
 /** Layer 7 Individual Connection */

--- a/src/libserver/management.cpp
+++ b/src/libserver/management.cpp
@@ -80,7 +80,7 @@ Management_Connection::X_Get_PEIType (int16_t & val)
 }
 
 int
-Management_Connection::X_PropertyScan (Array < PropertyInfo > &p)
+Management_Connection::X_PropertyScan (std::vector < PropertyInfo > &p)
 {
   p.resize (0);
   PropertyInfo p1;

--- a/src/libserver/management.h
+++ b/src/libserver/management.h
@@ -57,7 +57,7 @@ public:
   /** reads PEI type */
   int X_Get_PEIType (int16_t & val);
   /** scans all properties */
-  int X_PropertyScan (Array < PropertyInfo > &pi);
+  int X_PropertyScan (std::vector < PropertyInfo > &pi);
 };
 
 class Management_Individual:public Layer7_Individual

--- a/src/libserver/managementclient.cpp
+++ b/src/libserver/managementclient.cpp
@@ -31,7 +31,7 @@ ReadIndividualAddresses (ClientConnPtr c, uint8_t *buf, size_t len)
       return;
     }
   CArray erg;
-  Array < eibaddr_t > e = b.A_IndividualAddress_Read (c->t);
+  std::vector < eibaddr_t > e = b.A_IndividualAddress_Read (c->t);
   erg.resize (2 + 2 * e.size());
   EIBSETTYPE (erg, EIB_M_INDIVIDUAL_ADDRESS_READ);
   for (unsigned i = 0; i < e.size(); i++)
@@ -158,7 +158,7 @@ WriteIndividualAddress (ClientConnPtr c, uint8_t *buf, size_t len)
 	return;
       }
   }
-  Array < eibaddr_t > addr = b.A_IndividualAddress_Read (c->t);
+  std::vector < eibaddr_t > addr = b.A_IndividualAddress_Read (c->t);
   if (addr.size() > 1)
     {
       c->sendreject (EIB_ERROR_MORE_DEVICE);
@@ -448,7 +448,7 @@ ManagementConnection::ManagementConnection (ClientConnPtr c, uint8_t *buf, size_
 
 	  case EIB_MC_PROP_SCAN:
 	    {
-	      Array < PropertyInfo > p;
+	      std::vector < PropertyInfo > p;
 	      if (m.X_PropertyScan (p) == -1)
 		c->sendreject ();
 	      else

--- a/src/libserver/router.h
+++ b/src/libserver/router.h
@@ -181,7 +181,7 @@ private:
   Queue < LDataPtr > buf;
   Queue < LBusmonPtr > mbuf;
   /** buffer for packets to ignore when repeat flag is set */
-  Array < IgnoreInfo > ignore;
+  std::vector < IgnoreInfo > ignore;
 
   /** Start of address block to assign dynamically to clients */
   eibaddr_t client_addrs_start;
@@ -195,9 +195,9 @@ public:
 
 private:
   /** busmonitor callbacks */
-  Array < Busmonitor_Info > busmonitor;
+  std::vector < Busmonitor_Info > busmonitor;
   /** vbusmonitor callbacks */
-  Array < Busmonitor_Info > vbusmonitor;
+  std::vector < Busmonitor_Info > vbusmonitor;
 
   /** flag whether some driver is active */
   bool some_running = false;

--- a/src/libserver/server.h
+++ b/src/libserver/server.h
@@ -41,7 +41,7 @@ private:
   ev::io io; void io_cb (ev::io &w, int revents);
 
   /** open client connections*/
-  Array < ClientConnPtr > connections;
+  std::vector < ClientConnPtr > connections;
 
   ev::async cleanup;
   void cleanup_cb (ev::async &w, int revents);

--- a/src/server/knxd_args.cpp
+++ b/src/server/knxd_args.cpp
@@ -122,7 +122,7 @@ public:
 
 public:
   /** The current tracer */
-  Array < std::string > filters;
+  std::vector < std::string > filters;
 
   arguments () { }
   virtual ~arguments () { }

--- a/src/usb/usb.h
+++ b/src/usb/usb.h
@@ -29,7 +29,7 @@ class USBLoop
 {
   TracePtr t;
 
-  Array < ev::io * > fds;
+  std::vector < ev::io * > fds;
   ev::timer tm;
   void timer();
 


### PR DESCRIPTION
Signed-off-by: Tobias Lorenz <tobias.lorenz@gmx.net>