### PR TITLE
Drop legacy String and use std::string instead

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -23,11 +23,11 @@
 #include "loadctl.h"
 #include "image.h"
 
-String
+std::string
 HexDump (CArray data)
 {
   char buf[200];
-  String s;
+  std::string s;
   unsigned int i;
   sprintf (buf, "%04X ", 0);
   s = buf;
@@ -112,11 +112,11 @@ STR_Invalid::toArray ()
   return data;
 }
 
-String
+std::string
 STR_Invalid::decode ()
 {
   char buf[200];
-  String s;
+  std::string s;
   sprintf (buf, "Invalid:\n");
   s = buf;
   return s + HexDump (data);
@@ -144,11 +144,11 @@ STR_Unknown::toArray ()
   return d;
 }
 
-String
+std::string
 STR_Unknown::decode ()
 {
   char buf[200];
-  String s;
+  std::string s;
   sprintf (buf, "Unknown %04x:\n", type);
   s = buf;
   return s + HexDump (data);
@@ -178,7 +178,7 @@ STR_BCUType::toArray ()
   return d;
 }
 
-String
+std::string
 STR_BCUType::decode ()
 {
   char buf[200];
@@ -207,11 +207,11 @@ STR_Code::toArray ()
   return d;
 }
 
-String
+std::string
 STR_Code::decode ()
 {
   char buf[200];
-  String s;
+  std::string s;
   sprintf (buf, "Code:\n");
   s = buf;
   return s + HexDump (code);
@@ -254,7 +254,7 @@ STR_StringParameter::toArray ()
   return d;
 }
 
-String
+std::string
 STR_StringParameter::decode ()
 {
   char buf[200];
@@ -299,7 +299,7 @@ STR_IntParameter::toArray ()
   return d;
 }
 
-String
+std::string
 STR_IntParameter::decode ()
 {
   char buf[200];
@@ -342,7 +342,7 @@ STR_FloatParameter::toArray ()
   return d;
 }
 
-String
+std::string
 STR_FloatParameter::decode ()
 {
   char buf[200];
@@ -414,11 +414,11 @@ STR_ListParameter::toArray ()
   return d;
 }
 
-String
+std::string
 STR_ListParameter::decode ()
 {
   char buf[200];
-  String s;
+  std::string s;
   sprintf (buf, "ListParameter: addr=%04x id=%s elements=", addr, name.c_str());
   s = buf;
   for (unsigned int i = 0; i < elements.size(); i++)
@@ -448,7 +448,7 @@ STR_GroupObject::init (const CArray & c)
   return true;
 }
 
-String
+std::string
 STR_GroupObject::decode ()
 {
   char buf[200];
@@ -504,7 +504,7 @@ STR_BCU1Size::toArray ()
   return d;
 }
 
-String
+std::string
 STR_BCU1Size::decode ()
 {
   char buf[200];
@@ -552,7 +552,7 @@ STR_BCU2Size::toArray ()
   return d;
 }
 
-String
+std::string
 STR_BCU2Size::decode ()
 {
   char buf[200];
@@ -649,7 +649,7 @@ STR_BCU2Start::toArray ()
   return d;
 }
 
-String
+std::string
 STR_BCU2Start::decode ()
 {
   char buf[600];
@@ -705,11 +705,11 @@ STR_BCU2Key::toArray ()
 }
 
 
-String
+std::string
 STR_BCU2Key::decode ()
 {
   char buf[200];
-  String s;
+  std::string s;
   unsigned int i;
   sprintf (buf, "BCU2_KEY: install:%08X ", installkey);
   s = buf;
@@ -728,10 +728,10 @@ Image::~Image ()
       delete str[i];
 }
 
-String
+std::string
 Image::decode ()
 {
-  String s = "BCU Memory Image\n";
+  std::string s = "BCU Memory Image\n";
   for (unsigned int i = 0; i < str.size(); i++)
     s += str[i]->decode ();
   return s;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-String HexDump (CArray data);
+std::string HexDump (CArray data);
 
 typedef enum
 {
@@ -49,7 +49,7 @@ public:
   virtual bool init (const CArray & str) = 0;
   virtual CArray toArray () = 0;
   virtual STR_Type getType () = 0;
-  virtual String decode () = 0;
+  virtual std::string decode () = 0;
 };
 
 class STR_Invalid:public STR_Stream
@@ -64,7 +64,7 @@ public:
   {
     return S_Invalid;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_Unknown:public STR_Stream
@@ -80,7 +80,7 @@ public:
   {
     return S_Unknown;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_BCUType:public STR_Stream
@@ -95,7 +95,7 @@ public:
   {
     return S_BCUType;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_Code:public STR_Stream
@@ -110,7 +110,7 @@ public:
   {
     return S_Code;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_StringParameter:public STR_Stream
@@ -118,7 +118,7 @@ class STR_StringParameter:public STR_Stream
 public:
   uint16_t addr = 0;
   uint16_t length = 0;
-  String name;
+  std::string name;
 
     STR_StringParameter () = default;
   bool init (const CArray & str);
@@ -127,15 +127,15 @@ public:
   {
     return S_StringParameter;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_ListParameter:public STR_Stream
 {
 public:
   uint16_t addr = 0;
-  String name;
-    std::vector < String > elements;
+  std::string name;
+    std::vector < std::string > elements;
 
     STR_ListParameter () = default;
   bool init (const CArray & str);
@@ -144,7 +144,7 @@ public:
   {
     return S_ListParameter;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_IntParameter:public STR_Stream
@@ -152,7 +152,7 @@ class STR_IntParameter:public STR_Stream
 public:
   uint16_t addr;
   int8_t type = 0;
-  String name = "";
+  std::string name = "";
 
     STR_IntParameter () = default;
   bool init (const CArray & str);
@@ -161,14 +161,14 @@ public:
   {
     return S_IntParameter;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_FloatParameter:public STR_Stream
 {
 public:
   uint16_t addr = 0;
-  String name;
+  std::string name;
 
     STR_FloatParameter () = default;
   bool init (const CArray & str);
@@ -177,14 +177,14 @@ public:
   {
     return S_FloatParameter;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_GroupObject:public STR_Stream
 {
 public:
   uchar no = 0;
-  String name;
+  std::string name;
 
     STR_GroupObject () = default;
   bool init (const CArray & str);
@@ -193,7 +193,7 @@ public:
   {
     return S_GroupObject;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_BCU1Size:public STR_Stream
@@ -211,7 +211,7 @@ public:
   {
     return S_BCU1Size;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_BCU2Size:public STR_Stream
@@ -231,7 +231,7 @@ public:
   {
     return S_BCU2Size;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_BCU2Start:public STR_Stream
@@ -268,7 +268,7 @@ public:
   {
     return S_BCU2Start;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class STR_BCU2Key:public STR_Stream
@@ -284,7 +284,7 @@ public:
   {
     return S_BCU2Key;
   }
-  String decode ();
+  std::string decode ();
 };
 
 class Image
@@ -297,7 +297,7 @@ public:
 
   static Image *fromArray (CArray c);
   CArray toArray ();
-  String decode ();
+  std::string decode ();
   bool isValid ();
 
   int findStreamNumber (STR_Type t);

--- a/src/common/loadimage.cpp
+++ b/src/common/loadimage.cpp
@@ -467,7 +467,7 @@ PrepareLoadImage (const CArray & im, BCUImage * &img)
 
 #define _(A) (A)
 
-String
+std::string
 decodeBCULoadResult (BCU_LOAD_RESULT r)
 {
   switch (r)

--- a/src/common/loadimage.h
+++ b/src/common/loadimage.h
@@ -52,6 +52,6 @@ public:
 
 BCU_LOAD_RESULT PrepareLoadImage (const CArray & c, BCUImage * &img);
 
-String decodeBCULoadResult (BCU_LOAD_RESULT r);
+std::string decodeBCULoadResult (BCU_LOAD_RESULT r);
 
 #endif

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -44,9 +44,6 @@ typedef uint16_t eibaddr_t;
 /** EIB key */
 typedef uint32_t eibkey_type;
 
-/** legacy */
-typedef std::string String;
-
 #define ITER(_i,_t) for(decltype(_t)::iterator _i = _t.begin(); _i != _t.end(); _i++)
 #define R_ITER(_i,_t) for(decltype(_t)::reverse_iterator _i = _t.rbegin(); _i != _t.rend(); _i++)
 

--- a/src/libserver/apdu.cpp
+++ b/src/libserver/apdu.cpp
@@ -194,9 +194,9 @@ CArray A_Unknown_PDU::ToPacket ()
   return pdu;
 }
 
-String A_Unknown_PDU::Decode (TracePtr tr UNUSED)
+std::string A_Unknown_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("Unknown APDU: ");
+  std::string s ("Unknown APDU: ");
 
   if (pdu.size() == 0)
     return "empty APDU";
@@ -232,7 +232,7 @@ CArray A_GroupValue_Read_PDU::ToPacket ()
   return CArray (c, 2);
 }
 
-String A_GroupValue_Read_PDU::Decode (TracePtr tr UNUSED)
+std::string A_GroupValue_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   return "A_GroupValue_Read";
 }
@@ -282,10 +282,10 @@ CArray A_GroupValue_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String A_GroupValue_Response_PDU::Decode (TracePtr tr UNUSED)
+std::string A_GroupValue_Response_PDU::Decode (TracePtr tr UNUSED)
 {
   assert (!issmall || (data.size() == 1 && (data[0] & 0xC0) == 0));
-  String
+  std::string
   s ("A_GroupValue_Response ");
   if (issmall)
     s += "(small) ";
@@ -341,12 +341,12 @@ CArray A_GroupValue_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String A_GroupValue_Write_PDU::Decode (TracePtr tr UNUSED)
+std::string A_GroupValue_Write_PDU::Decode (TracePtr tr UNUSED)
 {
   unsigned
     i;
   assert (!issmall || (data.size() == 1 && (data[0] & 0xC0) == 0));
-  String
+  std::string
   s ("A_GroupValue_Write ");
   if (issmall)
     s += "(small) ";
@@ -385,9 +385,9 @@ CArray A_IndividualAddress_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String A_IndividualAddress_Write_PDU::Decode (TracePtr tr UNUSED)
+std::string A_IndividualAddress_Write_PDU::Decode (TracePtr tr UNUSED)
 {
-  String
+  std::string
   s ("A_IndividualAddress_Write ");
   return s + FormatEIBAddr (addr);
 }
@@ -416,7 +416,7 @@ CArray A_IndividualAddress_Read_PDU::ToPacket ()
   return CArray (c, 2);
 }
 
-String A_IndividualAddress_Read_PDU::Decode (TracePtr tr UNUSED)
+std::string A_IndividualAddress_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   return "A_IndividualAddress_Read";
 }
@@ -447,7 +447,7 @@ CArray A_IndividualAddress_Response_PDU::ToPacket ()
   return CArray (c, 2);
 }
 
-String A_IndividualAddress_Response_PDU::Decode (TracePtr tr UNUSED)
+std::string A_IndividualAddress_Response_PDU::Decode (TracePtr tr UNUSED)
 {
   return "A_IndividualAddress_Response";
 }
@@ -485,9 +485,9 @@ CArray A_IndividualAddressSerialNumber_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String A_IndividualAddressSerialNumber_Read_PDU::Decode (TracePtr tr UNUSED)
+std::string A_IndividualAddressSerialNumber_Read_PDU::Decode (TracePtr tr UNUSED)
 {
-  String
+  std::string
   s ("A_IndividualAddressSerialNumber_Read ");
   addHex (s, serno[0]);
   addHex (s, serno[1]);
@@ -538,9 +538,9 @@ CArray A_IndividualAddressSerialNumber_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String A_IndividualAddressSerialNumber_Response_PDU::Decode (TracePtr tr UNUSED)
+std::string A_IndividualAddressSerialNumber_Response_PDU::Decode (TracePtr tr UNUSED)
 {
-  String
+  std::string
   s ("A_IndividualAddressSerialNumber_Response ");
   addHex (s, serno[0]);
   addHex (s, serno[1]);
@@ -600,9 +600,9 @@ CArray A_IndividualAddressSerialNumber_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String A_IndividualAddressSerialNumber_Write_PDU::Decode (TracePtr tr UNUSED)
+std::string A_IndividualAddressSerialNumber_Write_PDU::Decode (TracePtr tr UNUSED)
 {
-  String
+  std::string
   s ("A_IndividualAddressSerialNumber_Write ");
   addHex (s, serno[0]);
   addHex (s, serno[1]);
@@ -650,10 +650,10 @@ A_ServiceInformation_Indication_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_ServiceInformation_Indication_Write_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_ServiceInformation_Indication_Write ");
+  std::string s ("A_ServiceInformation_Indication_Write ");
   if (verify_mode)
     s += "verify ";
   if (duplicate_address)
@@ -694,9 +694,9 @@ CArray A_DomainAddress_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String A_DomainAddress_Write_PDU::Decode (TracePtr tr UNUSED)
+std::string A_DomainAddress_Write_PDU::Decode (TracePtr tr UNUSED)
 {
-  String
+  std::string
   s ("A_DomainAddress_Write ");
   return s + FormatDomainAddr (addr);
 }
@@ -726,7 +726,7 @@ CArray A_DomainAddress_Read_PDU::ToPacket ()
   return CArray (c, 2);
 }
 
-String A_DomainAddress_Read_PDU::Decode (TracePtr tr UNUSED)
+std::string A_DomainAddress_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   return "A_DomainAddress_Read";
 }
@@ -759,9 +759,9 @@ CArray A_DomainAddress_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String A_DomainAddress_Response_PDU::Decode (TracePtr tr UNUSED)
+std::string A_DomainAddress_Response_PDU::Decode (TracePtr tr UNUSED)
 {
-  String
+  std::string
   s ("A_DomainAddress_Response");
   s += FormatDomainAddr (addr);
   return s;
@@ -800,10 +800,10 @@ CArray A_DomainAddressSelective_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_DomainAddressSelective_Read_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_DomainAddressSelective_Read ");
+  std::string s ("A_DomainAddressSelective_Read ");
   s += FormatDomainAddr (domainaddr);
   s += " ";
   s += FormatEIBAddr (addr);
@@ -847,12 +847,12 @@ A_PropertyValue_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_PropertyValue_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert ((start & 0xf000) == 0);
-  String s ("A_PropertyValue_Read Obj:");
+  std::string s ("A_PropertyValue_Read Obj:");
   addHex (s, obj);
   s += " Prop: ";
   addHex (s, prop);
@@ -900,12 +900,12 @@ A_PropertyValue_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_PropertyValue_Response_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert ((start & 0xf000) == 0);
-  String s ("A_PropertyValue_Response Obj:");
+  std::string s ("A_PropertyValue_Response Obj:");
   addHex (s, obj);
   s += " Prop: ";
   addHex (s, prop);
@@ -977,12 +977,12 @@ A_PropertyValue_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_PropertyValue_Write_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert ((start & 0xf000) == 0);
-  String s ("A_PropertyValue_Write Obj:");
+  std::string s ("A_PropertyValue_Write Obj:");
   addHex (s, obj);
   s += " Prop: ";
   addHex (s, prop);
@@ -1027,10 +1027,10 @@ A_PropertyDescription_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_PropertyDescription_Read_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_PropertyDescription_Read Obj: ");
+  std::string s ("A_PropertyDescription_Read Obj: ");
   addHex (s, obj);
   s += " Property: ";
   addHex (s, prop);
@@ -1077,10 +1077,10 @@ A_PropertyDescription_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_PropertyDescription_Response_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_PropertyDescription_Response Obj:");
+  std::string s ("A_PropertyDescription_Response Obj:");
   addHex (s, obj);
   s += " Property: ";
   addHex (s, prop);
@@ -1128,11 +1128,11 @@ A_DeviceDescriptor_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_DeviceDescriptor_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((type & 0xC0) == 0);
-  String s ("A_DeviceDescriptor_Read Type:");
+  std::string s ("A_DeviceDescriptor_Read Type:");
   addHex (s, type);
   return s;
 }
@@ -1169,11 +1169,11 @@ A_DeviceDescriptor_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_DeviceDescriptor_Response_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((type & 0xC0) == 0);
-  String s ("A_DeviceDescriptor_Response Type:");
+  std::string s ("A_DeviceDescriptor_Response Type:");
   addHex (s, type);
   s += " Descriptor: ";
   add16Hex (s, descriptor);
@@ -1215,11 +1215,11 @@ A_ADC_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_ADC_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((channel & 0xC0) == 0);
-  String s ("A_ADC_Read Channel:");
+  std::string s ("A_ADC_Read Channel:");
   addHex (s, channel);
   s += " Count: ";
   addHex (s, count);
@@ -1258,11 +1258,11 @@ A_ADC_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_ADC_Response_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((channel & 0xC0) == 0);
-  String s ("A_ADC_Response Channel:");
+  std::string s ("A_ADC_Response Channel:");
   addHex (s, channel);
   s += " Count: ";
   addHex (s, count);
@@ -1309,11 +1309,11 @@ A_Memory_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Memory_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
-  String s ("A_Memory_Read Len: ");
+  std::string s ("A_Memory_Read Len: ");
   addHex (s, count);
   s += " Addr: ";
   add16Hex (s, addr);
@@ -1355,12 +1355,12 @@ A_Memory_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Memory_Response_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert (data.size() == count);
-  String s ("A_Memory_Response Len:");
+  std::string s ("A_Memory_Response Len:");
   addHex (s, count);
   s += " Addr: ";
   add16Hex (s, addr);
@@ -1413,12 +1413,12 @@ A_Memory_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Memory_Write_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert (data.size() == count);
-  String s ("A_Memory_Write Len:");
+  std::string s ("A_Memory_Write Len:");
   addHex (s, count);
   s += " Addr: ";
   add16Hex (s, addr);
@@ -1466,12 +1466,12 @@ A_MemoryBit_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_MemoryBit_Write_PDU::Decode (TracePtr tr UNUSED)
 {
   assert (andmask.size() == count);
   assert (xormask.size() == count);
-  String s ("A_MemoryBit_Write Len:");
+  std::string s ("A_MemoryBit_Write Len:");
   addHex (s, count);
   s += "Addr: ";
   add16Hex (s, addr);
@@ -1517,12 +1517,12 @@ A_UserMemory_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_UserMemory_Read_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert ((addr_extension & 0xf0) == 0);
-  String s ("A_UserMemory_Read Addr_ext:");
+  std::string s ("A_UserMemory_Read Addr_ext:");
   addHex (s, addr_extension);
   s += " Len: ";
   addHex (s, count);
@@ -1569,13 +1569,13 @@ A_UserMemory_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_UserMemory_Response_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert ((addr_extension & 0xf0) == 0);
   assert (data.size() == count);
-  String s ("A_UserMemory_Response Addr_ext:");
+  std::string s ("A_UserMemory_Response Addr_ext:");
   addHex (s, addr_extension);
   s += " Len: ";
   addHex (s, count);
@@ -1635,13 +1635,13 @@ A_UserMemory_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_UserMemory_Write_PDU::Decode (TracePtr tr UNUSED)
 {
   assert ((count & 0xf0) == 0);
   assert ((addr_extension & 0xf0) == 0);
   assert (data.size() == count);
-  String s ("A_UserMemory_Write Addr_ext:");
+  std::string s ("A_UserMemory_Write Addr_ext:");
   addHex (s, addr_extension);
   s += " Len: ";
   addHex (s, count);
@@ -1691,12 +1691,12 @@ A_UserMemoryBit_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_UserMemoryBit_Write_PDU::Decode (TracePtr tr UNUSED)
 {
   assert (andmask.size() == count);
   assert (xormask.size() == count);
-  String s ("A_UserMemoryBit_Write Len:");
+  std::string s ("A_UserMemoryBit_Write Len:");
   addHex (s, count);
   s += "Addr: ";
   add16Hex (s, addr);
@@ -1733,10 +1733,10 @@ A_UserManufacturerInfo_Read_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_UserManufacturerInfo_Read_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_UserManufacturerInfo_Read");
+  std::string s ("A_UserManufacturerInfo_Read");
   return s;
 }
 
@@ -1770,10 +1770,10 @@ A_UserManufacturerInfo_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_UserManufacturerInfo_Response_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_UserManufactueerInfo_Response Manufacturer:");
+  std::string s ("A_UserManufactueerInfo_Response Manufacturer:");
   addHex (s, manufacturerid);
   s += " data: ";
   add16Hex (s, data);
@@ -1805,10 +1805,10 @@ A_Restart_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Restart_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_Restart");
+  std::string s ("A_Restart");
   return s;
 }
 
@@ -1843,10 +1843,10 @@ A_Authorize_Request_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Authorize_Request_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_Authorize_Request Key:");
+  std::string s ("A_Authorize_Request Key:");
   return s + FormatEIBKey (key);
 }
 
@@ -1877,10 +1877,10 @@ A_Authorize_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Authorize_Response_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_Authorize_Response Level:");
+  std::string s ("A_Authorize_Response Level:");
   addHex (s, level);
   return s;
 }
@@ -1917,10 +1917,10 @@ A_Key_Write_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Key_Write_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_Key_Write Level:");
+  std::string s ("A_Key_Write Level:");
   addHex (s, level);
   s += " Key: ";
   return s + FormatEIBKey (key);
@@ -1953,10 +1953,10 @@ A_Key_Response_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 A_Key_Response_PDU::Decode (TracePtr tr UNUSED)
 {
-  String s ("A_Key_Response Level:");
+  std::string s ("A_Key_Response Level:");
   addHex (s, level);
   return s;
 }

--- a/src/libserver/apdu.h
+++ b/src/libserver/apdu.h
@@ -81,7 +81,7 @@ public:
   /** convert to character array */
   virtual CArray ToPacket () = 0;
   /** decode content as string */
-  virtual String Decode (TracePtr t) = 0;
+  virtual std::string Decode (TracePtr t) = 0;
 
   /** converts character array to a APDU */
   static APDUPtr fromPacket (const CArray &, TracePtr t);
@@ -99,7 +99,7 @@ public:
   A_Unknown_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Unknown;
@@ -114,7 +114,7 @@ public:
   A_GroupValue_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_GroupValue_Read;
@@ -131,7 +131,7 @@ public:
   A_GroupValue_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_GroupValue_Response;
@@ -148,7 +148,7 @@ public:
   A_GroupValue_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_GroupValue_Write;
@@ -163,7 +163,7 @@ public:
   A_IndividualAddress_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_IndividualAddress_Read;
@@ -178,7 +178,7 @@ public:
   A_IndividualAddress_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_IndividualAddress_Response;
@@ -194,7 +194,7 @@ public:
   A_IndividualAddress_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_IndividualAddress_Write;
@@ -210,7 +210,7 @@ public:
   A_IndividualAddressSerialNumber_Read_PDU ();
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_IndividualAddressSerialNumber_Read;
@@ -227,7 +227,7 @@ public:
   A_IndividualAddressSerialNumber_Response_PDU ();
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_IndividualAddressSerialNumber_Response;
@@ -244,7 +244,7 @@ public:
   A_IndividualAddressSerialNumber_Write_PDU ();
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_IndividualAddressSerialNumber_Write;
@@ -262,7 +262,7 @@ public:
   A_ServiceInformation_Indication_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_ServiceInformation_Indication_Write;
@@ -278,7 +278,7 @@ public:
   A_DomainAddress_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_DomainAddress_Write;
@@ -293,7 +293,7 @@ public:
   A_DomainAddress_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_DomainAddress_Read;
@@ -309,7 +309,7 @@ public:
   A_DomainAddress_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_DomainAddress_Response;
@@ -327,7 +327,7 @@ public:
     A_DomainAddressSelective_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_DomainAddressSelective_Read;
@@ -346,7 +346,7 @@ public:
   A_PropertyValue_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_PropertyValue_Read;
@@ -366,7 +366,7 @@ public:
   A_PropertyValue_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_PropertyValue_Response;
@@ -386,7 +386,7 @@ public:
   A_PropertyValue_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_PropertyValue_Write;
@@ -404,7 +404,7 @@ public:
   A_PropertyDescription_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_PropertyDescription_Read;
@@ -425,7 +425,7 @@ public:
   A_PropertyDescription_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_PropertyDescription_Read;
@@ -441,7 +441,7 @@ public:
   A_DeviceDescriptor_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_DeviceDescriptor_Read;
@@ -458,7 +458,7 @@ public:
   A_DeviceDescriptor_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_DeviceDescriptor_Response;
@@ -475,7 +475,7 @@ public:
   A_ADC_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_ADC_Read;
@@ -493,7 +493,7 @@ public:
   A_ADC_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_ADC_Response;
@@ -510,7 +510,7 @@ public:
   A_Memory_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Memory_Read;
@@ -528,7 +528,7 @@ public:
   A_Memory_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Memory_Response;
@@ -546,7 +546,7 @@ public:
   A_Memory_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Memory_Write;
@@ -565,7 +565,7 @@ public:
   A_MemoryBit_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_MemoryBit_Write;
@@ -583,7 +583,7 @@ public:
   A_UserMemory_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_UserMemory_Read;
@@ -602,7 +602,7 @@ public:
   A_UserMemory_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_UserMemory_Response;
@@ -621,7 +621,7 @@ public:
   A_UserMemory_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_UserMemory_Write;
@@ -641,7 +641,7 @@ public:
   A_UserMemoryBit_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_UserMemoryBit_Write;
@@ -656,7 +656,7 @@ public:
   A_UserManufacturerInfo_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_UserManufacturerInfo_Read;
@@ -673,7 +673,7 @@ public:
   A_UserManufacturerInfo_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_UserManufacturerInfo_Response;
@@ -688,7 +688,7 @@ public:
   A_Restart_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Restart;
@@ -704,7 +704,7 @@ public:
   A_Authorize_Request_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Authorize_Request;
@@ -720,7 +720,7 @@ public:
   A_Authorize_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Authorize_Response;
@@ -737,7 +737,7 @@ public:
   A_Key_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Key_Write;
@@ -753,7 +753,7 @@ public:
   A_Key_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   APDU_type getType () const
   {
     return A_Key_Response;

--- a/src/libserver/busmonitor.cpp
+++ b/src/libserver/busmonitor.cpp
@@ -120,7 +120,7 @@ void
 A_Text_Busmonitor::send_L_Busmonitor (LBusmonPtr p)
 {
   CArray buf;
-  String s = p->Decode (t);
+  std::string s = p->Decode (t);
   buf.resize (2 + s.length() + 1);
   EIBSETTYPE (buf, EIB_BUSMONITOR_PACKET);
   buf.setpart ((uint8_t *)s.c_str(), 2, s.length()+1);

--- a/src/libserver/common.cpp
+++ b/src/libserver/common.cpp
@@ -31,7 +31,7 @@ getTime ()
   return ((timestamp_t) t.tv_sec) * 1000000 + ((timestamp_t) t.tv_usec);
 }
 
-String
+std::string
 FormatEIBAddr (eibaddr_t addr)
 {
   char buf[255];
@@ -40,7 +40,7 @@ FormatEIBAddr (eibaddr_t addr)
   return buf;
 }
 
-String
+std::string
 FormatGroupAddr (eibaddr_t addr)
 {
   char buf[255];
@@ -49,7 +49,7 @@ FormatGroupAddr (eibaddr_t addr)
   return buf;
 }
 
-String
+std::string
 FormatDomainAddr (domainaddr_t addr)
 {
   char buf[255];
@@ -57,7 +57,7 @@ FormatDomainAddr (domainaddr_t addr)
   return buf;
 }
 
-String
+std::string
 FormatEIBKey (eibkey_type key)
 {
   char buf[255];
@@ -66,7 +66,7 @@ FormatEIBKey (eibkey_type key)
 }
 
 void
-addHex (String & s, uchar c)
+addHex (std::string & s, uchar c)
 {
   char buf[4];
   sprintf (buf, "%02X ", c);
@@ -74,7 +74,7 @@ addHex (String & s, uchar c)
 }
 
 void
-add16Hex (String & s, uint16_t c)
+add16Hex (std::string & s, uint16_t c)
 {
   char buf[6];
   sprintf (buf, "%04X ", c);

--- a/src/libserver/common.h
+++ b/src/libserver/common.h
@@ -60,24 +60,24 @@ typedef enum
  * @param s string
  * @param c byte
  */
-void addHex (String & s, uchar c);
+void addHex (std::string & s, uchar c);
 /** add c to s as hex value
  * @param s string
  * @param c 16 bit int
  */
-void add16Hex (String & s, uint16_t c);
+void add16Hex (std::string & s, uint16_t c);
 
 /** get current time */
 timestamp_t getTime ();
 
 /** formats an EIB individual address */
-String FormatEIBAddr (eibaddr_t a);
+std::string FormatEIBAddr (eibaddr_t a);
 /** formats an EIB group address */
-String FormatGroupAddr (eibaddr_t a);
+std::string FormatGroupAddr (eibaddr_t a);
 /** formats an EIB domain address */
-String FormatDomainAddr (domainaddr_t addr);
+std::string FormatDomainAddr (domainaddr_t addr);
 /** formats an EIB key */
-String FormatEIBKey (eibkey_type addr);
+std::string FormatEIBKey (eibkey_type addr);
 
 #include "trace.h"
 

--- a/src/libserver/layer4.cpp
+++ b/src/libserver/layer4.cpp
@@ -54,7 +54,7 @@ T_Broadcast::recv_Data (const CArray & c)
 {
   T_DATA_XXX_REQ_PDU t;
   t.data = c;
-  String s = t.Decode (this->t);
+  std::string s = t.Decode (this->t);
   TRACEPRINTF (this->t, 4, "Recv Broadcast %s", s);
   LDataPtr l = LDataPtr(new L_Data_PDU ());
   l->source = 0;
@@ -98,7 +98,7 @@ T_Group::recv_Data (const CArray & c)
 {
   T_DATA_XXX_REQ_PDU t;
   t.data = c;
-  String s = t.Decode (this->t);
+  std::string s = t.Decode (this->t);
   TRACEPRINTF (this->t, 4, "Recv Group %s", s);
   LDataPtr l = LDataPtr(new L_Data_PDU ());
   l->source = 0;
@@ -184,7 +184,7 @@ T_Individual::recv_Data (const CArray & c)
 {
   T_DATA_XXX_REQ_PDU t;
   t.data = c;
-  String s = t.Decode (this->t);
+  std::string s = t.Decode (this->t);
   TRACEPRINTF (this->t, 4, "Recv Individual %s", s);
   LDataPtr l = LDataPtr(new L_Data_PDU ());
   l->source = 0;
@@ -445,7 +445,7 @@ GroupSocket::recv_Data (const GroupAPDU & c)
 {
   T_DATA_XXX_REQ_PDU t;
   t.data = c.data;
-  String s = t.Decode (this->t);
+  std::string s = t.Decode (this->t);
   TRACEPRINTF (this->t, 4, "Recv GroupSocket %s %s", FormatGroupAddr(c.dst), s);
   LDataPtr l = LDataPtr(new L_Data_PDU ());
   l->source = 0;

--- a/src/libserver/lpdu.cpp
+++ b/src/libserver/lpdu.cpp
@@ -64,7 +64,7 @@ CArray L_NACK_PDU::ToPacket ()
   return CArray (&c, 1);
 }
 
-String L_NACK_PDU::Decode (TracePtr t UNUSED)
+std::string L_NACK_PDU::Decode (TracePtr t UNUSED)
 {
   return "NACK";
 }
@@ -89,7 +89,7 @@ CArray L_ACK_PDU::ToPacket ()
   return CArray (&c, 1);
 }
 
-String L_ACK_PDU::Decode (TracePtr t UNUSED)
+std::string L_ACK_PDU::Decode (TracePtr t UNUSED)
 {
   return "ACK";
 }
@@ -114,7 +114,7 @@ CArray L_BUSY_PDU::ToPacket ()
   return CArray (&c, 1);
 }
 
-String L_BUSY_PDU::Decode (TracePtr t UNUSED)
+std::string L_BUSY_PDU::Decode (TracePtr t UNUSED)
 {
   return "BUSY";
 }
@@ -138,10 +138,10 @@ L_Unknown_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 L_Unknown_PDU::Decode (TracePtr t UNUSED)
 {
-  String s ("Unknown LPDU: ");
+  std::string s ("Unknown LPDU: ");
 
   if (pdu.size() == 0)
     return "empty LPDU";
@@ -175,10 +175,10 @@ L_Busmonitor_PDU::ToPacket ()
   return pdu;
 }
 
-String
+std::string
 L_Busmonitor_PDU::Decode (TracePtr t)
 {
-  String s ("LPDU: ");
+  std::string s ("LPDU: ");
 
   if (pdu.size() == 0)
     return "empty LPDU";
@@ -325,13 +325,13 @@ CArray L_Data_PDU::ToPacket ()
   return pdu;
 }
 
-String L_Data_PDU::Decode (TracePtr t)
+std::string L_Data_PDU::Decode (TracePtr t)
 {
   assert (data.size() >= 1);
   assert (data.size() <= 0xff);
   assert ((hopcount & 0xf8) == 0);
 
-  String s ("L_Data");
+  std::string s ("L_Data");
   if (!valid_length)
     s += " (incomplete)";
   if (repeated)

--- a/src/libserver/lpdu.h
+++ b/src/libserver/lpdu.h
@@ -63,7 +63,7 @@ public:
   /** convert to a character array */
   virtual CArray ToPacket () = 0;
   /** decode content as string */
-  virtual String Decode (TracePtr t) = 0;
+  virtual std::string Decode (TracePtr t) = 0;
   /** get frame type */
   virtual LPDU_Type getType () const = 0;
   /** converts a character array to a Layer 2 frame */
@@ -82,7 +82,7 @@ public:
 
   bool init (const CArray & c);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   LPDU_Type getType () const
   {
     return L_Unknown;
@@ -114,7 +114,7 @@ public:
 
   bool init (const CArray & c);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   LPDU_Type getType () const
   {
     return (valid_length ? L_Data : L_Data_Part);
@@ -135,7 +135,7 @@ public:
 
   bool init (const CArray & c);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   LPDU_Type getType () const
   {
     return L_Busmonitor;
@@ -150,7 +150,7 @@ public:
 
   bool init (const CArray & c);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   LPDU_Type getType () const
   {
     return L_ACK;
@@ -165,7 +165,7 @@ public:
 
   bool init (const CArray & c);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   LPDU_Type getType () const
   {
     return L_NACK;
@@ -180,7 +180,7 @@ public:
 
   bool init (const CArray & c);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   LPDU_Type getType () const
   {
     return L_BUSY;

--- a/src/libserver/tpdu.cpp
+++ b/src/libserver/tpdu.cpp
@@ -62,9 +62,9 @@ CArray T_UNKNOWN_PDU::ToPacket ()
   return pdu;
 }
 
-String T_UNKNOWN_PDU::Decode (TracePtr t UNUSED)
+std::string T_UNKNOWN_PDU::Decode (TracePtr t UNUSED)
 {
-  String s ("Unknown TPDU: ");
+  std::string s ("Unknown TPDU: ");
 
   if (pdu.size() == 0)
     return "empty TPDU";
@@ -94,10 +94,10 @@ CArray T_DATA_XXX_REQ_PDU::ToPacket ()
   return pdu;
 }
 
-String T_DATA_XXX_REQ_PDU::Decode (TracePtr t)
+std::string T_DATA_XXX_REQ_PDU::Decode (TracePtr t)
 {
   APDUPtr a = APDU::fromPacket (data, t);
-  String s ("T_DATA_XXX_REQ ");
+  std::string s ("T_DATA_XXX_REQ ");
   s += a->Decode (t);
   return s;
 }
@@ -123,11 +123,11 @@ CArray T_DATA_CONNECTED_REQ_PDU::ToPacket ()
   return pdu;
 }
 
-String T_DATA_CONNECTED_REQ_PDU::Decode (TracePtr t)
+std::string T_DATA_CONNECTED_REQ_PDU::Decode (TracePtr t)
 {
   assert ((serno & 0xf0) == 0);
   APDUPtr a = APDU::fromPacket (data, t);
-  String s ("T_DATA_CONNECTED_REQ serno:");
+  std::string s ("T_DATA_CONNECTED_REQ serno:");
   addHex (s, serno);
   s += a->Decode (t);
   return s;
@@ -149,7 +149,7 @@ CArray T_CONNECT_REQ_PDU::ToPacket ()
   return CArray (&c, 1);
 }
 
-String T_CONNECT_REQ_PDU::Decode (TracePtr t UNUSED)
+std::string T_CONNECT_REQ_PDU::Decode (TracePtr t UNUSED)
 {
   return "T_CONNECT_REQ";
 }
@@ -170,7 +170,7 @@ CArray T_DISCONNECT_REQ_PDU::ToPacket ()
   return CArray (&c, 1);
 }
 
-String T_DISCONNECT_REQ_PDU::Decode (TracePtr t UNUSED)
+std::string T_DISCONNECT_REQ_PDU::Decode (TracePtr t UNUSED)
 {
   return "T_DISCONNECT_REQ";
 }
@@ -193,10 +193,10 @@ CArray T_ACK_PDU::ToPacket ()
   return CArray (&c, 1);
 }
 
-String T_ACK_PDU::Decode (TracePtr t UNUSED)
+std::string T_ACK_PDU::Decode (TracePtr t UNUSED)
 {
   assert ((serno & 0xf0) == 0);
-  String s ("T_ACK Serno:");
+  std::string s ("T_ACK Serno:");
   addHex (s, serno);
   return s;
 }
@@ -218,10 +218,10 @@ CArray T_NACK_PDU::ToPacket ()
   return CArray (&c, 1);
 }
 
-String T_NACK_PDU::Decode (TracePtr t UNUSED)
+std::string T_NACK_PDU::Decode (TracePtr t UNUSED)
 {
   assert ((serno & 0xf0) == 0);
-  String s ("T_NACK Serno:");
+  std::string s ("T_NACK Serno:");
   addHex (s, serno);
   return s;
 }

--- a/src/libserver/tpdu.h
+++ b/src/libserver/tpdu.h
@@ -55,7 +55,7 @@ public:
   /** convert to character array */
   virtual CArray ToPacket () = 0;
   /** decode content as string */
-  virtual String Decode (TracePtr t) = 0;
+  virtual std::string Decode (TracePtr t) = 0;
   /** gets TPDU type */
   virtual TPDU_Type getType () const = 0;
   /** converts character array to a TPDU */
@@ -70,7 +70,7 @@ public:
   T_UNKNOWN_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   TPDU_Type getType () const
   {
     return T_UNKNOWN;
@@ -85,7 +85,7 @@ public:
   T_DATA_XXX_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   TPDU_Type getType () const
   {
     return T_DATA_XXX_REQ;
@@ -101,7 +101,7 @@ public:
   T_DATA_CONNECTED_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   TPDU_Type getType () const
   {
     return T_DATA_CONNECTED_REQ;
@@ -115,7 +115,7 @@ public:
   T_CONNECT_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   TPDU_Type getType () const
   {
     return T_CONNECT_REQ;
@@ -129,7 +129,7 @@ public:
   T_DISCONNECT_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   TPDU_Type getType () const
   {
     return T_DISCONNECT_REQ;
@@ -144,7 +144,7 @@ public:
   T_ACK_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   TPDU_Type getType () const
   {
     return T_ACK;
@@ -159,7 +159,7 @@ public:
   T_NACK_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
-  String Decode (TracePtr t);
+  std::string Decode (TracePtr t);
   TPDU_Type getType () const
   {
     return T_NACK;


### PR DESCRIPTION
Signed-off-by: Tobias Lorenz <tobias.lorenz@gmx.net>