### PR TITLE
Drop default constructor/destructor and use member initializers instead

### DIFF
--- a/src/backend/dummy.cpp
+++ b/src/backend/dummy.cpp
@@ -18,7 +18,3 @@
 */
 
 #include "dummy.h"
-
-DummyL2Driver::~DummyL2Driver() { }
-DummyL2Filter::~DummyL2Filter() { }
-

--- a/src/backend/dummy.h
+++ b/src/backend/dummy.h
@@ -26,7 +26,7 @@ DRIVER(DummyL2Driver,dummy)
 {
 public:
   DummyL2Driver (const LinkConnectPtr_& c, IniSectionPtr& s) : BusDriver(c,s) {}
-  virtual ~DummyL2Driver ();
+  virtual ~DummyL2Driver () = default;
 
   void send_L_Data (LDataPtr l UNUSED) { send_Next(); }
   bool setup()
@@ -42,7 +42,7 @@ FILTER(DummyL2Filter,dummy)
 {
 public:
   DummyL2Filter (const LinkConnectPtr_& c, IniSectionPtr& s) : Filter(c,s) {}
-  virtual ~DummyL2Filter ();
+  virtual ~DummyL2Filter () = default;
 };
 
 #endif

--- a/src/backend/ft12.cpp
+++ b/src/backend/ft12.cpp
@@ -32,14 +32,11 @@
 #include "lltcp.h"
 #include "log.h"
 
-FT12Driver::~FT12Driver() {}
-FT12cemiDriver::~FT12cemiDriver() {}
-
 class FT12serial : public LLserial
 {
 public:
   FT12serial(LowLevelIface* a, IniSectionPtr& b) : LLserial(a,b) { t->setAuxName("FT12_ser"); }
-  virtual ~FT12serial() {}
+  virtual ~FT12serial() = default;
 protected:
   void termios_settings (struct termios &t1)
     {

--- a/src/backend/ft12.h
+++ b/src/backend/ft12.h
@@ -49,7 +49,7 @@ public:
     {
       t->setAuxName("ft12dr");
     }
-  virtual ~FT12Driver();
+  virtual ~FT12Driver() = default;
 
   bool setup();
   virtual EMIVer getVersion() { return vEMI2; }
@@ -64,7 +64,7 @@ public:
     {
       t->setAuxName("ft12drc");
     }
-  virtual ~FT12cemiDriver();
+  virtual ~FT12cemiDriver() = default;
 
   virtual EMIVer getVersion() { return vCEMI; }
 };

--- a/src/backend/log.cpp
+++ b/src/backend/log.cpp
@@ -19,8 +19,6 @@
 
 #include "log.h"
 
-LogFilter::~LogFilter() { }
-
 bool
 LogFilter::setup()
 {

--- a/src/backend/log.h
+++ b/src/backend/log.h
@@ -32,7 +32,7 @@ FILTER(LogFilter,log)
 
 public:
   LogFilter (const LinkConnectPtr_& c, IniSectionPtr& s) : Filter(c,s) {}
-  virtual ~LogFilter ();
+  virtual ~LogFilter () = default;
 
   virtual bool setup();
   virtual void recv_L_Data (LDataPtr l);

--- a/src/backend/ncn5120.cpp
+++ b/src/backend/ncn5120.cpp
@@ -22,13 +22,11 @@
 #include "ncn5120.h"
 #include "llserial.h"
 
-NCN5120::~NCN5120() { }
-
 class NCN5120wrap : public TPUARTwrap
 {
 public:
   NCN5120wrap (LowLevelIface* parent, IniSectionPtr& s, LowLevelDriver* i = nullptr) : TPUARTwrap(parent,s,i) {}
-  virtual ~NCN5120wrap() {}
+  virtual ~NCN5120wrap() = default;
 
 protected:
   void termios_settings(struct termios &t);
@@ -43,7 +41,7 @@ class NCN5120serial : public LLserial
 {
 public:
   NCN5120serial(LowLevelIface* a, IniSectionPtr& b) : LLserial(a,b) { t->setAuxName("NCN_ser"); }
-  virtual ~NCN5120serial () {};
+  virtual ~NCN5120serial () = default;
 
 protected:
   unsigned int default_baudrate() { return 38400; }

--- a/src/backend/ncn5120.h
+++ b/src/backend/ncn5120.h
@@ -40,7 +40,7 @@ DRIVER_(NCN5120,TPUART,ncn5120)
 {
 public:
   NCN5120 (const LinkConnectPtr_& c, IniSectionPtr& s) : TPUART(c,s) { t->setAuxName("NCN"); } ;
-  virtual ~NCN5120 ();
+  virtual ~NCN5120 () = default;
   LowLevelFilter * create_wrapper(LowLevelIface* parent, IniSectionPtr& s, LowLevelDriver* i = nullptr);
 };
 

--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -31,13 +31,11 @@
 #include "lltcp.h"
 #include "log.h"
 
-TPUART::~TPUART() {}
-
 class TPUARTserial : public LLserial
 {
 public:
   TPUARTserial(LowLevelIface* a, IniSectionPtr& b) : LLserial(a,b) { t->setAuxName("TPU_ser"); }
-  virtual ~TPUARTserial();
+  virtual ~TPUARTserial() = default;
 protected:
   void termios_settings (struct termios &t1)
     {
@@ -157,8 +155,6 @@ TPUARTwrap::~TPUARTwrap ()
   timer.stop();
   sendtimer.stop();
 }
-
-TPUARTserial::~TPUARTserial() {}
 
 void
 TPUARTwrap::send_L_Data (LDataPtr l)

--- a/src/backend/tpuart.h
+++ b/src/backend/tpuart.h
@@ -47,7 +47,7 @@ public:
     {
       t->setAuxName("tpuart");
     }
-  virtual ~TPUART();
+  virtual ~TPUART() = default;
 
   bool setup();
 protected:

--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -99,10 +99,6 @@ STR_Stream::fromArray (const CArray & c)
   return i;
 }
 
-STR_Invalid::STR_Invalid ()
-{
-}
-
 bool
 STR_Invalid::init (const CArray & c)
 {
@@ -124,12 +120,6 @@ STR_Invalid::decode ()
   sprintf (buf, "Invalid:\n");
   s = buf;
   return s + HexDump (data);
-}
-
-
-STR_Unknown::STR_Unknown ()
-{
-  type = 0;
 }
 
 bool
@@ -164,11 +154,6 @@ STR_Unknown::decode ()
   return s + HexDump (data);
 }
 
-STR_BCUType::STR_BCUType ()
-{
-  bcutype = 0;
-}
-
 bool
 STR_BCUType::init (const CArray & c)
 {
@@ -201,10 +186,6 @@ STR_BCUType::decode ()
   return buf;
 }
 
-STR_Code::STR_Code ()
-{
-}
-
 bool
 STR_Code::init (const CArray & c)
 {
@@ -234,12 +215,6 @@ STR_Code::decode ()
   sprintf (buf, "Code:\n");
   s = buf;
   return s + HexDump (code);
-}
-
-STR_StringParameter::STR_StringParameter ()
-{
-  addr = 0;
-  length = 0;
 }
 
 bool
@@ -288,12 +263,6 @@ STR_StringParameter::decode ()
   return buf;
 }
 
-STR_IntParameter::STR_IntParameter ()
-{
-  name = "";
-  type = 0;
-}
-
 bool
 STR_IntParameter::init (const CArray & c)
 {
@@ -339,11 +308,6 @@ STR_IntParameter::decode ()
   return buf;
 }
 
-STR_FloatParameter::STR_FloatParameter ()
-{
-  addr = 0;
-}
-
 bool
 STR_FloatParameter::init (const CArray & c)
 {
@@ -384,11 +348,6 @@ STR_FloatParameter::decode ()
   char buf[200];
   sprintf (buf, "FloatParameter: addr=%04x id=%s\n", addr, name.c_str());
   return buf;
-}
-
-STR_ListParameter::STR_ListParameter ()
-{
-  addr = 0;
 }
 
 bool
@@ -471,11 +430,6 @@ STR_ListParameter::decode ()
   return s;
 }
 
-STR_GroupObject::STR_GroupObject ()
-{
-  no = 0;
-}
-
 bool
 STR_GroupObject::init (const CArray & c)
 {
@@ -515,14 +469,6 @@ STR_GroupObject::toArray ()
   d[4] = (no) & 0xff;
   d.setpart (name, 5);
   return d;
-}
-
-STR_BCU1Size::STR_BCU1Size ()
-{
-  textsize = 0;
-  stacksize = 0;
-  datasize = 0;
-  bsssize = 0;
 }
 
 bool
@@ -565,16 +511,6 @@ STR_BCU1Size::decode ()
   sprintf (buf, "BCU1_SIZE: text:%d stack:%d data:%d bss:%d\n", textsize,
 	   stacksize, datasize, bsssize);
   return buf;
-}
-
-STR_BCU2Size::STR_BCU2Size ()
-{
-  textsize = 0;
-  stacksize = 0;
-  lo_datasize = 0;
-  lo_bsssize = 0;
-  hi_datasize = 0;
-  hi_bsssize = 0;
 }
 
 bool
@@ -625,33 +561,6 @@ STR_BCU2Size::decode ()
 	   textsize, stacksize, lo_datasize, lo_bsssize, hi_datasize,
 	   hi_bsssize);
   return buf;
-}
-
-STR_BCU2Start::STR_BCU2Start ()
-{
-  addrtab_start = 0;
-  addrtab_size = 0;
-  assoctab_start = 0;
-  assoctab_size = 0;
-  readonly_start = 0;
-  readonly_end = 0;
-  param_start = 0;
-  param_end = 0;
-
-  obj_ptr = 0;
-  obj_count = 0;
-  appcallback = 0;
-  groupobj_ptr = 0;
-  seg0 = 0;
-  seg1 = 0;
-  sphandler = 0;
-  initaddr = 0;
-  runaddr = 0;
-  saveaddr = 0;
-  eeprom_start = 0;
-  eeprom_end = 0;
-  poll_addr = 0;
-  poll_slot = 0;
 }
 
 bool
@@ -756,11 +665,6 @@ STR_BCU2Start::decode ()
   return buf;
 }
 
-STR_BCU2Key::STR_BCU2Key ()
-{
-  installkey = 0xFFFFFFFF;
-}
-
 bool
 STR_BCU2Key::init (const CArray & c)
 {
@@ -815,10 +719,6 @@ STR_BCU2Key::decode ()
       s += buf;
     }
   return s;
-}
-
-Image::Image ()
-{
 }
 
 Image::~Image ()

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -44,9 +44,7 @@ typedef enum
 class STR_Stream
 {
 public:
-  virtual ~STR_Stream ()
-  {
-  }
+  virtual ~STR_Stream () = default;
   static STR_Stream *fromArray (const CArray & c);
   virtual bool init (const CArray & str) = 0;
   virtual CArray toArray () = 0;
@@ -59,7 +57,7 @@ class STR_Invalid:public STR_Stream
 public:
   CArray data;
 
-  STR_Invalid ();
+  STR_Invalid () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -72,10 +70,10 @@ public:
 class STR_Unknown:public STR_Stream
 {
 public:
-  uint16_t type;
+  uint16_t type = 0;
   CArray data;
 
-    STR_Unknown ();
+    STR_Unknown () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -88,9 +86,9 @@ public:
 class STR_BCUType:public STR_Stream
 {
 public:
-  uint16_t bcutype;
+  uint16_t bcutype = 0;
 
-  STR_BCUType ();
+  STR_BCUType () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -105,7 +103,7 @@ class STR_Code:public STR_Stream
 public:
   CArray code;
 
-  STR_Code ();
+  STR_Code () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -118,11 +116,11 @@ public:
 class STR_StringParameter:public STR_Stream
 {
 public:
-  uint16_t addr;
-  uint16_t length;
+  uint16_t addr = 0;
+  uint16_t length = 0;
   String name;
 
-    STR_StringParameter ();
+    STR_StringParameter () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -135,11 +133,11 @@ public:
 class STR_ListParameter:public STR_Stream
 {
 public:
-  uint16_t addr;
+  uint16_t addr = 0;
   String name;
     std::vector < String > elements;
 
-    STR_ListParameter ();
+    STR_ListParameter () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -153,10 +151,10 @@ class STR_IntParameter:public STR_Stream
 {
 public:
   uint16_t addr;
-  int8_t type;
-  String name;
+  int8_t type = 0;
+  String name = "";
 
-    STR_IntParameter ();
+    STR_IntParameter () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -169,10 +167,10 @@ public:
 class STR_FloatParameter:public STR_Stream
 {
 public:
-  uint16_t addr;
+  uint16_t addr = 0;
   String name;
 
-    STR_FloatParameter ();
+    STR_FloatParameter () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -185,10 +183,10 @@ public:
 class STR_GroupObject:public STR_Stream
 {
 public:
-  uchar no;
+  uchar no = 0;
   String name;
 
-    STR_GroupObject ();
+    STR_GroupObject () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -201,12 +199,12 @@ public:
 class STR_BCU1Size:public STR_Stream
 {
 public:
-  uint16_t textsize;
-  uint16_t stacksize;
-  uint16_t datasize;
-  uint16_t bsssize;
+  uint16_t textsize = 0;
+  uint16_t stacksize = 0;
+  uint16_t datasize = 0;
+  uint16_t bsssize = 0;
 
-    STR_BCU1Size ();
+    STR_BCU1Size () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -219,14 +217,14 @@ public:
 class STR_BCU2Size:public STR_Stream
 {
 public:
-  uint16_t textsize;
-  uint16_t stacksize;
-  uint16_t lo_datasize;
-  uint16_t lo_bsssize;
-  uint16_t hi_datasize;
-  uint16_t hi_bsssize;
+  uint16_t textsize = 0;
+  uint16_t stacksize = 0;
+  uint16_t lo_datasize = 0;
+  uint16_t lo_bsssize = 0;
+  uint16_t hi_datasize = 0;
+  uint16_t hi_bsssize = 0;
 
-    STR_BCU2Size ();
+    STR_BCU2Size () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -239,31 +237,31 @@ public:
 class STR_BCU2Start:public STR_Stream
 {
 public:
-  uint16_t addrtab_start;
-  uint16_t addrtab_size;
-  uint16_t assoctab_start;
-  uint16_t assoctab_size;
-  uint16_t readonly_start;
-  uint16_t readonly_end;
-  uint16_t param_start;
-  uint16_t param_end;
+  uint16_t addrtab_start = 0;
+  uint16_t addrtab_size = 0;
+  uint16_t assoctab_start = 0;
+  uint16_t assoctab_size = 0;
+  uint16_t readonly_start = 0;
+  uint16_t readonly_end = 0;
+  uint16_t param_start = 0;
+  uint16_t param_end = 0;
 
-  uint16_t obj_ptr;
-  uint16_t obj_count;
-  uint16_t appcallback;
-  uint16_t groupobj_ptr;
-  uint16_t seg0;
-  uint16_t seg1;
-  uint16_t sphandler;
-  uint16_t initaddr;
-  uint16_t runaddr;
-  uint16_t saveaddr;
-  uint16_t eeprom_start;
-  uint16_t eeprom_end;
-  eibaddr_t poll_addr;
-  uint8_t poll_slot;
+  uint16_t obj_ptr = 0;
+  uint16_t obj_count = 0;
+  uint16_t appcallback = 0;
+  uint16_t groupobj_ptr = 0;
+  uint16_t seg0 = 0;
+  uint16_t seg1 = 0;
+  uint16_t sphandler = 0;
+  uint16_t initaddr = 0;
+  uint16_t runaddr = 0;
+  uint16_t saveaddr = 0;
+  uint16_t eeprom_start = 0;
+  uint16_t eeprom_end = 0;
+  eibaddr_t poll_addr = 0;
+  uint8_t poll_slot = 0;
 
-    STR_BCU2Start ();
+    STR_BCU2Start () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -276,10 +274,10 @@ public:
 class STR_BCU2Key:public STR_Stream
 {
 public:
-  eibkey_type installkey;
+  eibkey_type installkey = 0xFFFFFFFF;
   std::vector < eibkey_type > keys;
 
-  STR_BCU2Key ();
+  STR_BCU2Key () = default;
   bool init (const CArray & str);
   CArray toArray ();
   STR_Type getType ()
@@ -294,7 +292,7 @@ class Image
 public:
   std::vector < STR_Stream * >str;
 
-  Image ();
+  Image () = default;
   virtual ~Image ();
 
   static Image *fromArray (CArray c);

--- a/src/common/iobuf.h
+++ b/src/common/iobuf.h
@@ -117,7 +117,7 @@ public:
     on_read.set<RecvBuf,&RecvBuf::recv_cb>(this);
   };
   void low_latency() { quick = true; }
-  virtual ~RecvBuf() {};
+  virtual ~RecvBuf() = default;
 
   void start();
   void stop(bool clear = false);

--- a/src/common/queue.h
+++ b/src/common/queue.h
@@ -34,7 +34,7 @@ public:
   Queue () : std::queue<_T>() {};
 
   /** destructor */
-  virtual ~Queue () {}
+  virtual ~Queue () = default;
 
   using std::queue<_T>::front;
   using std::queue<_T>::pop;

--- a/src/libserver/apdu.cpp
+++ b/src/libserver/apdu.cpp
@@ -182,10 +182,6 @@ APDU::fromPacket (const CArray & c, TracePtr tr)
 
 /* A_Unknown_PDU */
 
-A_Unknown_PDU::A_Unknown_PDU ()
-{
-}
-
 bool
 A_Unknown_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -219,10 +215,6 @@ bool A_Unknown_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_GroupValue_Read */
 
-A_GroupValue_Read_PDU::A_GroupValue_Read_PDU ()
-{
-}
-
 bool
 A_GroupValue_Read_PDU::init (const CArray & c, TracePtr tr UNUSED UNUSED)
 {
@@ -251,11 +243,6 @@ bool A_GroupValue_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_GroupValue_Response */
-
-A_GroupValue_Response_PDU::A_GroupValue_Response_PDU ()
-{
-  issmall = 0;
-}
 
 bool
 A_GroupValue_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -315,11 +302,6 @@ bool A_GroupValue_Response_PDU::isResponse (const APDU * req) const
 }
 
 /* A_GroupValue_Write */
-
-A_GroupValue_Write_PDU::A_GroupValue_Write_PDU ()
-{
-  issmall = 0;
-}
 
 bool
 A_GroupValue_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -382,11 +364,6 @@ bool A_GroupValue_Write_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_IndividualAddress_Write */
 
-A_IndividualAddress_Write_PDU::A_IndividualAddress_Write_PDU ()
-{
-  addr = 0;
-}
-
 bool
 A_IndividualAddress_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -422,10 +399,6 @@ bool A_IndividualAddress_Write_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_IndividualAddress_Read */
 
-A_IndividualAddress_Read_PDU::A_IndividualAddress_Read_PDU ()
-{
-}
-
 bool
 A_IndividualAddress_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -454,10 +427,6 @@ bool A_IndividualAddress_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_IndividualAddress_Response */
-
-A_IndividualAddress_Response_PDU::A_IndividualAddress_Response_PDU ()
-{
-}
 
 bool A_IndividualAddress_Response_PDU::init (const CArray & c, TracePtr tr)
 {
@@ -542,7 +511,6 @@ A_IndividualAddressSerialNumber_Response_PDU::
 A_IndividualAddressSerialNumber_Response_PDU ()
 {
   memset (serno, 0, sizeof (serno));
-  addr = 0;
 }
 
 bool
@@ -604,7 +572,6 @@ A_IndividualAddressSerialNumber_Write_PDU::
 A_IndividualAddressSerialNumber_Write_PDU ()
 {
   memset (serno, 0, sizeof (serno));
-  addr = 0;
 }
 
 bool A_IndividualAddressSerialNumber_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -657,14 +624,6 @@ bool
 
 /* A_ServiceInformation_Indication_Write_PDU */
 
-A_ServiceInformation_Indication_Write_PDU::
-A_ServiceInformation_Indication_Write_PDU ()
-{
-  verify_mode = 0;
-  duplicate_address = 0;
-  appl_stopped = 0;
-}
-
 bool
 A_ServiceInformation_Indication_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -714,11 +673,6 @@ bool
 
 /* A_DomainAddress_Write */
 
-A_DomainAddress_Write_PDU::A_DomainAddress_Write_PDU ()
-{
-  addr = 0;
-}
-
 bool
 A_DomainAddress_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -755,10 +709,6 @@ bool A_DomainAddress_Write_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_DomainAddress_Read */
 
-A_DomainAddress_Read_PDU::A_DomainAddress_Read_PDU ()
-{
-}
-
 bool
 A_DomainAddress_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -787,11 +737,6 @@ bool A_DomainAddress_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_DomainAddress_Response */
-
-A_DomainAddress_Response_PDU::A_DomainAddress_Response_PDU ()
-{
-  addr = 0;
-}
 
 bool
 A_DomainAddress_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -828,13 +773,6 @@ bool A_DomainAddress_Response_PDU::isResponse (const APDU * req) const
 }
 
 /* A_DomainAddressSelective_Read */
-
-A_DomainAddressSelective_Read_PDU::A_DomainAddressSelective_Read_PDU ()
-{
-  domainaddr = 0;
-  addr = 0;
-  range = 0;
-}
 
 bool
 A_DomainAddressSelective_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -880,14 +818,6 @@ bool A_DomainAddressSelective_Read_PDU::isResponse (const APDU * req UNUSED) con
 }
 
 /* A_PropertyValue_Read */
-
-A_PropertyValue_Read_PDU::A_PropertyValue_Read_PDU ()
-{
-  obj = 0;
-  prop = 0;
-  count = 0;
-  start = 0;
-}
 
 bool
 A_PropertyValue_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -939,14 +869,6 @@ bool A_PropertyValue_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_PropertyValue_Response */
-
-A_PropertyValue_Response_PDU::A_PropertyValue_Response_PDU ()
-{
-  obj = 0;
-  prop = 0;
-  count = 0;
-  start = 0;
-}
 
 bool
 A_PropertyValue_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1025,14 +947,6 @@ bool A_PropertyValue_Response_PDU::isResponse (const APDU * req) const
 
 /* A_PropertyValue_Write */
 
-A_PropertyValue_Write_PDU::A_PropertyValue_Write_PDU ()
-{
-  obj = 0;
-  prop = 0;
-  count = 0;
-  start = 0;
-}
-
 bool
 A_PropertyValue_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1089,13 +1003,6 @@ bool A_PropertyValue_Write_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_PropertyDescription_Read */
 
-A_PropertyDescription_Read_PDU::A_PropertyDescription_Read_PDU ()
-{
-  obj = 0;
-  prop = 0;
-  property_index = 0;
-}
-
 bool
 A_PropertyDescription_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1138,16 +1045,6 @@ bool A_PropertyDescription_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_PropertyDescription_Response */
-
-A_PropertyDescription_Response_PDU::A_PropertyDescription_Response_PDU ()
-{
-  obj = 0;
-  prop = 0;
-  property_index = 0;
-  type = 0;
-  count = 0;
-  access = 0;
-}
 
 bool
 A_PropertyDescription_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1211,11 +1108,6 @@ bool A_PropertyDescription_Response_PDU::isResponse (const APDU * req) const
 
 /* A_DeviceDescriptor_Read */
 
-A_DeviceDescriptor_Read_PDU::A_DeviceDescriptor_Read_PDU ()
-{
-  type = 0;
-}
-
 bool
 A_DeviceDescriptor_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1251,12 +1143,6 @@ bool A_DeviceDescriptor_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_DeviceDescriptor_Response */
-
-A_DeviceDescriptor_Response_PDU::A_DeviceDescriptor_Response_PDU ()
-{
-  type = 0;
-  descriptor = 0;
-}
 
 bool A_DeviceDescriptor_Response_PDU::init (const CArray & c, TracePtr tr)
 {
@@ -1307,12 +1193,6 @@ bool A_DeviceDescriptor_Response_PDU::isResponse (const APDU * req) const
 
 /* A_ADC_Read */
 
-A_ADC_Read_PDU::A_ADC_Read_PDU ()
-{
-  channel = 0;
-  count = 0;
-}
-
 bool
 A_ADC_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1352,13 +1232,6 @@ bool A_ADC_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_ADC_Response */
-
-A_ADC_Response_PDU::A_ADC_Response_PDU ()
-{
-  channel = 0;
-  count = 0;
-  val = 0;
-}
 
 bool
 A_ADC_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1413,12 +1286,6 @@ bool A_ADC_Response_PDU::isResponse (const APDU * req) const
 
 /* A_Memory_Read */
 
-A_Memory_Read_PDU::A_Memory_Read_PDU ()
-{
-  count = 0;
-  addr = 0;
-}
-
 bool
 A_Memory_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1459,12 +1326,6 @@ bool A_Memory_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_Memory_Response */
-
-A_Memory_Response_PDU::A_Memory_Response_PDU ()
-{
-  count = 0;
-  addr = 0;
-}
 
 bool
 A_Memory_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1524,12 +1385,6 @@ bool A_Memory_Response_PDU::isResponse (const APDU * req) const
 
 /* A_Memory_Write */
 
-A_Memory_Write_PDU::A_Memory_Write_PDU ()
-{
-  count = 0;
-  addr = 0;
-}
-
 bool
 A_Memory_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1579,12 +1434,6 @@ bool A_Memory_Write_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_MemoryBit_Write */
-
-A_MemoryBit_Write_PDU::A_MemoryBit_Write_PDU ()
-{
-  count = 0;
-  addr = 0;
-}
 
 bool
 A_MemoryBit_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1642,13 +1491,6 @@ bool A_MemoryBit_Write_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_UserMemory_Read */
 
-A_UserMemory_Read_PDU::A_UserMemory_Read_PDU ()
-{
-  addr_extension = 0;
-  count = 0;
-  addr = 0;
-}
-
 bool
 A_UserMemory_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1695,13 +1537,6 @@ bool A_UserMemory_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_UserMemory_Response */
-
-A_UserMemory_Response_PDU::A_UserMemory_Response_PDU ()
-{
-  addr_extension = 0;
-  count = 0;
-  addr = 0;
-}
 
 bool
 A_UserMemory_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1769,13 +1604,6 @@ bool A_UserMemory_Response_PDU::isResponse (const APDU * req) const
 
 /* A_UserMemory_Write */
 
-A_UserMemory_Write_PDU::A_UserMemory_Write_PDU ()
-{
-  addr_extension = 0;
-  count = 0;
-  addr = 0;
-}
-
 bool
 A_UserMemory_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -1831,13 +1659,6 @@ bool A_UserMemory_Write_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_UserMemoryBit_Write */
-
-A_UserMemoryBit_Write_PDU::A_UserMemoryBit_Write_PDU ()
-{
-  addr_extension = 0;
-  count = 0;
-  addr = 0;
-}
 
 bool
 A_UserMemoryBit_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1895,10 +1716,6 @@ bool A_UserMemoryBit_Write_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_UserManufacturerInfo_Read */
 
-A_UserManufacturerInfo_Read_PDU::A_UserManufacturerInfo_Read_PDU ()
-{
-}
-
 bool A_UserManufacturerInfo_Read_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
   if (c.size() != 2)
@@ -1929,12 +1746,6 @@ bool A_UserManufacturerInfo_Read_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_UserManufacturerInfo_Response */
-
-A_UserManufacturerInfo_Response_PDU::A_UserManufacturerInfo_Response_PDU ()
-{
-  manufacturerid = 0;
-  data = 0;
-}
 
 bool
 A_UserManufacturerInfo_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -1976,10 +1787,6 @@ bool A_UserManufacturerInfo_Response_PDU::isResponse (const APDU * req) const
 
 /* A_Restart */
 
-A_Restart_PDU::A_Restart_PDU ()
-{
-}
-
 bool
 A_Restart_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -2011,11 +1818,6 @@ bool A_Restart_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_Authorize_Request */
-
-A_Authorize_Request_PDU::A_Authorize_Request_PDU ()
-{
-  key = 0;
-}
 
 bool
 A_Authorize_Request_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -2055,11 +1857,6 @@ bool A_Authorize_Request_PDU::isResponse (const APDU * req UNUSED) const
 
 /* A_Authorize_Response */
 
-A_Authorize_Response_PDU::A_Authorize_Response_PDU ()
-{
-  level = 0;
-}
-
 bool
 A_Authorize_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)
 {
@@ -2094,12 +1891,6 @@ bool A_Authorize_Response_PDU::isResponse (const APDU * req) const
 }
 
 /* A_Key_Write */
-
-A_Key_Write_PDU::A_Key_Write_PDU ()
-{
-  key = 0;
-  level = 0;
-}
 
 bool
 A_Key_Write_PDU::init (const CArray & c, TracePtr tr UNUSED)
@@ -2141,11 +1932,6 @@ bool A_Key_Write_PDU::isResponse (const APDU * req UNUSED) const
 }
 
 /* A_Key_Response */
-
-A_Key_Response_PDU::A_Key_Response_PDU ()
-{
-  level = 0;
-}
 
 bool
 A_Key_Response_PDU::init (const CArray & c, TracePtr tr UNUSED)

--- a/src/libserver/apdu.h
+++ b/src/libserver/apdu.h
@@ -75,9 +75,7 @@ typedef std::unique_ptr<APDU> APDUPtr;
 class APDU
 {
 public:
-  virtual ~APDU ()
-  {
-  };
+  virtual ~APDU () = default;
 
   virtual bool init (const CArray &, TracePtr ) = 0;
   /** convert to character array */
@@ -98,7 +96,7 @@ class A_Unknown_PDU:public APDU
 public:
   CArray pdu;
 
-  A_Unknown_PDU ();
+  A_Unknown_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -113,7 +111,7 @@ class A_GroupValue_Read_PDU:public APDU
 {
 public:
 
-  A_GroupValue_Read_PDU ();
+  A_GroupValue_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -127,10 +125,10 @@ public:
 class A_GroupValue_Response_PDU:public APDU
 {
 public:
-  bool issmall;
+  bool issmall = 0;
   CArray data;
 
-  A_GroupValue_Response_PDU ();
+  A_GroupValue_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -144,10 +142,10 @@ public:
 class A_GroupValue_Write_PDU:public APDU
 {
 public:
-  bool issmall;
+  bool issmall = 0;
   CArray data;
 
-  A_GroupValue_Write_PDU ();
+  A_GroupValue_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -162,7 +160,7 @@ class A_IndividualAddress_Read_PDU:public APDU
 {
 public:
 
-  A_IndividualAddress_Read_PDU ();
+  A_IndividualAddress_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -177,7 +175,7 @@ class A_IndividualAddress_Response_PDU:public APDU
 {
 public:
 
-  A_IndividualAddress_Response_PDU ();
+  A_IndividualAddress_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -191,9 +189,9 @@ public:
 class A_IndividualAddress_Write_PDU:public APDU
 {
 public:
-  eibaddr_t addr;
+  eibaddr_t addr = 0;
 
-  A_IndividualAddress_Write_PDU ();
+  A_IndividualAddress_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -224,7 +222,7 @@ class A_IndividualAddressSerialNumber_Response_PDU:public APDU
 {
 public:
   serialnumber_t serno;
-  domainaddr_t addr;
+  domainaddr_t addr = 0;
 
   A_IndividualAddressSerialNumber_Response_PDU ();
   bool init (const CArray & p, TracePtr tr);
@@ -241,7 +239,7 @@ class A_IndividualAddressSerialNumber_Write_PDU:public APDU
 {
 public:
   serialnumber_t serno;
-  eibaddr_t addr;
+  eibaddr_t addr = 0;
 
   A_IndividualAddressSerialNumber_Write_PDU ();
   bool init (const CArray & p, TracePtr tr);
@@ -257,11 +255,11 @@ public:
 class A_ServiceInformation_Indication_Write_PDU:public APDU
 {
 public:
-  bool verify_mode;
-  bool duplicate_address;
-  bool appl_stopped;
+  bool verify_mode = 0;
+  bool duplicate_address = 0;
+  bool appl_stopped = 0;
 
-  A_ServiceInformation_Indication_Write_PDU ();
+  A_ServiceInformation_Indication_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -275,9 +273,9 @@ public:
 class A_DomainAddress_Write_PDU:public APDU
 {
 public:
-  domainaddr_t addr;
+  domainaddr_t addr = 0;
 
-  A_DomainAddress_Write_PDU ();
+  A_DomainAddress_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -292,7 +290,7 @@ class A_DomainAddress_Read_PDU:public APDU
 {
 public:
 
-  A_DomainAddress_Read_PDU ();
+  A_DomainAddress_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -306,9 +304,9 @@ public:
 class A_DomainAddress_Response_PDU:public APDU
 {
 public:
-  domainaddr_t addr;
+  domainaddr_t addr = 0;
 
-  A_DomainAddress_Response_PDU ();
+  A_DomainAddress_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -322,11 +320,11 @@ public:
 class A_DomainAddressSelective_Read_PDU:public APDU
 {
 public:
-  domainaddr_t domainaddr;
-  eibaddr_t addr;
-  uchar range;
+  domainaddr_t domainaddr = 0;
+  eibaddr_t addr = 0;
+  uchar range = 0;
 
-    A_DomainAddressSelective_Read_PDU ();
+    A_DomainAddressSelective_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -340,12 +338,12 @@ public:
 class A_PropertyValue_Read_PDU:public APDU
 {
 public:
-  objectno_t obj;
-  propertyid_t prop;
-  uchar count;
-  uint16_t start;
+  objectno_t obj = 0;
+  propertyid_t prop = 0;
+  uchar count = 0;
+  uint16_t start = 0;
 
-  A_PropertyValue_Read_PDU ();
+  A_PropertyValue_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -359,13 +357,13 @@ public:
 class A_PropertyValue_Response_PDU:public APDU
 {
 public:
-  objectno_t obj;
-  propertyid_t prop;
-  uchar count;
-  uint16_t start;
+  objectno_t obj = 0;
+  propertyid_t prop = 0;
+  uchar count = 0;
+  uint16_t start = 0;
   CArray data;
 
-  A_PropertyValue_Response_PDU ();
+  A_PropertyValue_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -379,13 +377,13 @@ public:
 class A_PropertyValue_Write_PDU:public APDU
 {
 public:
-  objectno_t obj;
-  propertyid_t prop;
-  uchar count;
-  uint16_t start;
+  objectno_t obj = 0;
+  propertyid_t prop = 0;
+  uchar count = 0;
+  uint16_t start = 0;
   CArray data;
 
-  A_PropertyValue_Write_PDU ();
+  A_PropertyValue_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -399,11 +397,11 @@ public:
 class A_PropertyDescription_Read_PDU:public APDU
 {
 public:
-  objectno_t obj;
-  propertyid_t prop;
-  uchar property_index;
+  objectno_t obj = 0;
+  propertyid_t prop = 0;
+  uchar property_index = 0;
 
-  A_PropertyDescription_Read_PDU ();
+  A_PropertyDescription_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -417,14 +415,14 @@ public:
 class A_PropertyDescription_Response_PDU:public APDU
 {
 public:
-  objectno_t obj;
-  propertyid_t prop;
-  uchar property_index;
-  uchar type;
-  uint16_t count;
-  uchar access;
+  objectno_t obj = 0;
+  propertyid_t prop = 0;
+  uchar property_index = 0;
+  uchar type = 0;
+  uint16_t count = 0;
+  uchar access = 0;
 
-  A_PropertyDescription_Response_PDU ();
+  A_PropertyDescription_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -438,9 +436,9 @@ public:
 class A_DeviceDescriptor_Read_PDU:public APDU
 {
 public:
-  uchar type;
+  uchar type = 0;
 
-  A_DeviceDescriptor_Read_PDU ();
+  A_DeviceDescriptor_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -454,10 +452,10 @@ public:
 class A_DeviceDescriptor_Response_PDU:public APDU
 {
 public:
-  uchar type;
-  uint16_t descriptor;
+  uchar type = 0;
+  uint16_t descriptor = 0;
 
-  A_DeviceDescriptor_Response_PDU ();
+  A_DeviceDescriptor_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -471,10 +469,10 @@ public:
 class A_ADC_Read_PDU:public APDU
 {
 public:
-  uchar channel;
-  uchar count;
+  uchar channel = 0;
+  uchar count = 0;
 
-  A_ADC_Read_PDU ();
+  A_ADC_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -488,11 +486,11 @@ public:
 class A_ADC_Response_PDU:public APDU
 {
 public:
-  uchar channel;
-  uchar count;
-  int16_t val;
+  uchar channel = 0;
+  uchar count = 0;
+  int16_t val = 0;
 
-  A_ADC_Response_PDU ();
+  A_ADC_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -506,10 +504,10 @@ public:
 class A_Memory_Read_PDU:public APDU
 {
 public:
-  uchar count;
-  memaddr_t addr;
+  uchar count = 0;
+  memaddr_t addr = 0;
 
-  A_Memory_Read_PDU ();
+  A_Memory_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -523,11 +521,11 @@ public:
 class A_Memory_Response_PDU:public APDU
 {
 public:
-  uchar count;
-  memaddr_t addr;
+  uchar count = 0;
+  memaddr_t addr = 0;
   CArray data;
 
-  A_Memory_Response_PDU ();
+  A_Memory_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -541,11 +539,11 @@ public:
 class A_Memory_Write_PDU:public APDU
 {
 public:
-  uchar count;
-  memaddr_t addr;
+  uchar count = 0;
+  memaddr_t addr = 0;
   CArray data;
 
-  A_Memory_Write_PDU ();
+  A_Memory_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -559,12 +557,12 @@ public:
 class A_MemoryBit_Write_PDU:public APDU
 {
 public:
-  uchar count;
-  memaddr_t addr;
+  uchar count = 0;
+  memaddr_t addr = 0;
   CArray andmask;
   CArray xormask;
 
-  A_MemoryBit_Write_PDU ();
+  A_MemoryBit_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -578,11 +576,11 @@ public:
 class A_UserMemory_Read_PDU:public APDU
 {
 public:
-  uchar addr_extension;
-  uchar count;
-  memaddr_t addr;
+  uchar addr_extension = 0;
+  uchar count = 0;
+  memaddr_t addr = 0;
 
-  A_UserMemory_Read_PDU ();
+  A_UserMemory_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -596,12 +594,12 @@ public:
 class A_UserMemory_Response_PDU:public APDU
 {
 public:
-  uchar addr_extension;
-  uchar count;
-  memaddr_t addr;
+  uchar addr_extension = 0;
+  uchar count = 0;
+  memaddr_t addr = 0;
   CArray data;
 
-  A_UserMemory_Response_PDU ();
+  A_UserMemory_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -615,12 +613,12 @@ public:
 class A_UserMemory_Write_PDU:public APDU
 {
 public:
-  uchar addr_extension;
-  uchar count;
-  memaddr_t addr;
+  uchar addr_extension = 0;
+  uchar count = 0;
+  memaddr_t addr = 0;
   CArray data;
 
-  A_UserMemory_Write_PDU ();
+  A_UserMemory_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -634,13 +632,13 @@ public:
 class A_UserMemoryBit_Write_PDU:public APDU
 {
 public:
-  uchar addr_extension;
-  uchar count;
-  memaddr_t addr;
+  uchar addr_extension = 0;
+  uchar count = 0;
+  memaddr_t addr = 0;
   CArray andmask;
   CArray xormask;
 
-  A_UserMemoryBit_Write_PDU ();
+  A_UserMemoryBit_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -655,7 +653,7 @@ class A_UserManufacturerInfo_Read_PDU:public APDU
 {
 public:
 
-  A_UserManufacturerInfo_Read_PDU ();
+  A_UserManufacturerInfo_Read_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -669,10 +667,10 @@ public:
 class A_UserManufacturerInfo_Response_PDU:public APDU
 {
 public:
-  uchar manufacturerid;
-  uint16_t data;
+  uchar manufacturerid = 0;
+  uint16_t data = 0;
 
-  A_UserManufacturerInfo_Response_PDU ();
+  A_UserManufacturerInfo_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -687,7 +685,7 @@ class A_Restart_PDU:public APDU
 {
 public:
 
-  A_Restart_PDU ();
+  A_Restart_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -701,9 +699,9 @@ public:
 class A_Authorize_Request_PDU:public APDU
 {
 public:
-  eibkey_type key;
+  eibkey_type key = 0;
 
-  A_Authorize_Request_PDU ();
+  A_Authorize_Request_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -717,9 +715,9 @@ public:
 class A_Authorize_Response_PDU:public APDU
 {
 public:
-  uchar level;
+  uchar level = 0;
 
-  A_Authorize_Response_PDU ();
+  A_Authorize_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -733,10 +731,10 @@ public:
 class A_Key_Write_PDU:public APDU
 {
 public:
-  uchar level;
-  eibkey_type key;
+  uchar level = 0;
+  eibkey_type key = 0;
 
-  A_Key_Write_PDU ();
+  A_Key_Write_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -750,9 +748,9 @@ public:
 class A_Key_Response_PDU:public APDU
 {
 public:
-  uchar level;
+  uchar level = 0;
 
-  A_Key_Response_PDU ();
+  A_Key_Response_PDU () = default;
   bool init (const CArray & p, TracePtr tr);
   CArray ToPacket ();
   String Decode (TracePtr t);

--- a/src/libserver/cemi.cpp
+++ b/src/libserver/cemi.cpp
@@ -36,10 +36,6 @@ CEMIDriver::CEMIDriver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i) :
   reset_timer.set<CEMIDriver,&CEMIDriver::reset_timer_cb>(this);
 }
 
-CEMIDriver::~CEMIDriver()
-{
-}
-
 void
 CEMIDriver::sendLocal_done_cb(bool success)
 {

--- a/src/libserver/cemi.h
+++ b/src/libserver/cemi.h
@@ -54,7 +54,7 @@ private:
 
 public:
   CEMIDriver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i = nullptr);
-  virtual ~CEMIDriver ();
+  virtual ~CEMIDriver () = default;
   void do_send_Next();
 };
 

--- a/src/libserver/connection.h
+++ b/src/libserver/connection.h
@@ -33,7 +33,7 @@ public:
       con = cc;
       on_error.set<A__Base,&A__Base::error_cb>(this);
     }
-  virtual ~A__Base() {}
+  virtual ~A__Base() = default;
 
   ClientConnPtr con;
   LinkConnectSinglePtr lc;

--- a/src/libserver/eibnetip.h
+++ b/src/libserver/eibnetip.h
@@ -118,9 +118,7 @@ public:
 				     const struct sockaddr_in src);
   /** convert to character array */
   CArray ToPacket () const;
-  virtual ~EIBNetIPPacket ()
-  {
-  }
+  virtual ~EIBNetIPPacket () = default;
 };
 
 class EIBnet_ConnectRequest

--- a/src/libserver/emi1.cpp
+++ b/src/libserver/emi1.cpp
@@ -26,10 +26,6 @@ EMI1Driver::EMI1Driver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i) :
   sendLocal_done.set<EMI1Driver,&EMI1Driver::sendLocal_done_cb>(this);
 }
 
-EMI1Driver::~EMI1Driver()
-{
-}
-
 void
 EMI1Driver::cmdEnterMonitor()
 {

--- a/src/libserver/emi1.h
+++ b/src/libserver/emi1.h
@@ -36,7 +36,7 @@ class EMI1Driver:public EMI_Common
   void do_send_Next();
 public:
   EMI1Driver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i = nullptr);
-  virtual ~EMI1Driver ();
+  virtual ~EMI1Driver () = default;
 };
 
 #endif

--- a/src/libserver/emi2.cpp
+++ b/src/libserver/emi2.cpp
@@ -26,10 +26,6 @@ EMI2Driver::EMI2Driver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i) :
   sendLocal_done.set<EMI2Driver,&EMI2Driver::sendLocal_done_cb>(this);
 }
 
-EMI2Driver::~EMI2Driver()
-{
-}
-
 void
 EMI2Driver::sendLocal_done_cb(bool success)
 {

--- a/src/libserver/emi2.h
+++ b/src/libserver/emi2.h
@@ -40,7 +40,7 @@ class EMI2Driver:public EMI_Common
   enum { N_bad, N_up, N_want_close, N_want_leave, N_down, N_open, N_enter } sendLocal_done_next = N_bad;
 public:
   EMI2Driver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i = nullptr);
-  virtual ~EMI2Driver ();
+  virtual ~EMI2Driver () = default;
   void do_send_Next();
 };
 

--- a/src/libserver/emi_common.cpp
+++ b/src/libserver/emi_common.cpp
@@ -67,10 +67,6 @@ EMI_Common::setup()
   return true;
 }
 
-EMI_Common::~EMI_Common ()
-{
-}
-
 void
 EMI_Common::start()
 {

--- a/src/libserver/emi_common.h
+++ b/src/libserver/emi_common.h
@@ -86,7 +86,7 @@ private:
 
 public:
   EMI_Common (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i = nullptr);
-  virtual ~EMI_Common ();
+  virtual ~EMI_Common () = default;
   bool setup();
   void start();
   void started();

--- a/src/libserver/layer4.cpp
+++ b/src/libserver/layer4.cpp
@@ -20,11 +20,6 @@
 #include "layer4.h"
 #include "tpdu.h"
 
-/***************** Layer4Common *****************/
-
-template<class COMM>
-Layer4common<COMM>::~Layer4common() {}
-
 /***************** T_Brodcast *****************/
 
 T_Broadcast::T_Broadcast (T_Reader<BroadcastComm> *app, LinkConnectClientPtr lc, bool write_only)

--- a/src/libserver/layer4.h
+++ b/src/libserver/layer4.h
@@ -77,7 +77,7 @@ protected:
   {
     this->app = app;
   };
-  virtual ~Layer4common();
+  virtual ~Layer4common() = default;
 public:
   bool setup() {
     if (!LineDriver::setup())

--- a/src/libserver/layer7.cpp
+++ b/src/libserver/layer7.cpp
@@ -82,10 +82,6 @@ Layer7_Connection::Layer7_Connection (TracePtr tr, eibaddr_t d)
   dest = d;
 }
 
-Layer7_Connection::~Layer7_Connection ()
-{
-}
-
 bool Layer7_Connection::setup()
 {
   l4 = T_ConnectionPtr(new T_Connection (t, dest));
@@ -382,10 +378,6 @@ Layer7_Individual::Layer7_Individual (TracePtr tr, eibaddr_t d)
   t = tr;
   TRACEPRINTF (t, 5, "L7Individual open");
   dest = d;
-}
-
-Layer7_Individual::~Layer7_Individual ()
-{
 }
 
 bool Layer7_Individual::setup()

--- a/src/libserver/layer7.h
+++ b/src/libserver/layer7.h
@@ -54,7 +54,7 @@ class Layer7_Connection : T_Reader<BroadcastComm>
   APDUPtr Request_Response (APDU * r);
 public:
   Layer7_Connection (TracePtr tr, eibaddr_t dest);
-  virtual ~Layer7_Connection ();
+  virtual ~Layer7_Connection () = default;
   bool init (Router * l3);
   void recv (BroadcastComm *c);
 
@@ -109,7 +109,7 @@ class Layer7_Individual
   APDUPtr Request_Response (APDU * r);
 public:
   Layer7_Individual (TracePtr tr, eibaddr_t dest);
-  virtual ~Layer7_Individual ();
+  virtual ~Layer7_Individual () = default;
   bool init (Router * l3);
 
   /** read a property */

--- a/src/libserver/link.cpp
+++ b/src/libserver/link.cpp
@@ -21,19 +21,6 @@
 #include "router.h"
 #include <stdio.h>
 
-LinkBase::~LinkBase() { }
-LinkRecv::~LinkRecv() { }
-Driver::~Driver() { }
-BusDriver::~BusDriver() { }
-SubDriver::~SubDriver() { }
-LineDriver::~LineDriver() { }
-LinkConnect_::~LinkConnect_() { }
-Filter::~Filter() { }
-Server::~Server() { }
-BaseRouter::~BaseRouter() { }
-LinkConnectClient::~LinkConnectClient() { }
-LinkConnectSingle::~LinkConnectSingle() { }
-
 bool
 LinkRecv::link(LinkBasePtr next)
 {

--- a/src/libserver/link.h
+++ b/src/libserver/link.h
@@ -139,7 +139,7 @@ class BaseRouter {
 protected: // can't instantiate this class directly
   BaseRouter(IniData &i) : ini(i) {}
 public:
-  virtual ~BaseRouter();
+  virtual ~BaseRouter() = default;
   /** debug output */
   TracePtr t;
 
@@ -222,7 +222,7 @@ class LinkBase : public std::enable_shared_from_this<LinkBase>
 {
 public:
   LinkBase(BaseRouter &r, IniSectionPtr& s, TracePtr tr);
-  virtual ~LinkBase();
+  virtual ~LinkBase() = default;
 private:
   /* DEBUG: Flag to make sure that the call sequence is observed */
   bool setup_called = false;
@@ -302,7 +302,7 @@ public:
     {
       t->setAuxName("Recv");
     }
-  virtual ~LinkRecv();
+  virtual ~LinkRecv() = default;
   /** Arriving data packet */
   virtual void recv_L_Data (LDataPtr l) = 0;
   /** Arriving monitor packet */
@@ -338,7 +338,7 @@ class LinkConnect_ : public LinkRecv
 {
 public:
   LinkConnect_(BaseRouter& r, IniSectionPtr& s, TracePtr tr);
-  virtual ~LinkConnect_();
+  virtual ~LinkConnect_() = default;
 
   BaseRouter& router;
 
@@ -479,7 +479,7 @@ public:
   ServerPtr server;
 
   LinkConnectClient(ServerPtr s, IniSectionPtr& c, TracePtr tr);
-  virtual ~LinkConnectClient();
+  virtual ~LinkConnectClient() = default;
 
   virtual const std::string& name() { return linkname; }
 };
@@ -492,7 +492,7 @@ public:
     {
       t->setAuxName("ConnS");
     }
-  virtual ~LinkConnectSingle();
+  virtual ~LinkConnectSingle() = default;
 
   virtual bool setup();
   virtual bool hasAddress (eibaddr_t addr) { return addr == this->addr; }
@@ -529,7 +529,7 @@ public:
     {
       t->setAuxName("Server");
     }
-  virtual ~Server();
+  virtual ~Server() = default;
 
   /** Server::setup() does NOT call LinkConnect::setup() because there is no driver here. */
   virtual bool setup();
@@ -571,7 +571,7 @@ public:
   typedef LinkConnectPtr_ first_arg;
 
   Filter(const LinkConnectPtr_& c, IniSectionPtr& s);
-  virtual ~Filter();
+  virtual ~Filter() = default;
 
 protected:
   /** Link to the receiver */
@@ -655,7 +655,7 @@ public:
       conn = c;
       t->setAuxName("Driver");
     }
-  virtual ~Driver();
+  virtual ~Driver() = default;
   std::weak_ptr<LinkConnect_> conn;
 
 protected:
@@ -709,7 +709,7 @@ public:
       addrs.resize(65536);
       t->setAuxName("BusDriver");
     }
-  virtual ~BusDriver();
+  virtual ~BusDriver() = default;
 
   virtual bool hasAddress(eibaddr_t addr) { return addrs[addr]; }
   virtual void addAddress(eibaddr_t addr) { addrs[addr] = true; }
@@ -723,7 +723,7 @@ class SubDriver : public BusDriver
 public:
   ServerPtr server;
   SubDriver(const LinkConnectClientPtr& c);
-  virtual ~SubDriver();
+  virtual ~SubDriver() = default;
 };
 
 /** Base class for server-linked drivers with a single client */
@@ -732,7 +732,7 @@ class LineDriver : public Driver
 public:
   ServerPtr server;
   LineDriver(const LinkConnectClientPtr& c);
-  virtual ~LineDriver();
+  virtual ~LineDriver() = default;
 
   virtual bool setup(); // assigns the address
 private:

--- a/src/libserver/llserial.cpp
+++ b/src/libserver/llserial.cpp
@@ -48,8 +48,6 @@ static speed_t getbaud(int baud) {
     }
 }
 
-LLserial::~LLserial () {}
-
 bool
 LLserial::setup()
 {

--- a/src/libserver/llserial.h
+++ b/src/libserver/llserial.h
@@ -45,7 +45,7 @@ public:
     {
       t->setAuxName("Serial");
     }
-  virtual ~LLserial ();
+  virtual ~LLserial () = default;
 
   bool setup();
   void start();

--- a/src/libserver/lltcp.cpp
+++ b/src/libserver/lltcp.cpp
@@ -30,8 +30,6 @@
 #include "ipsupport.h"
 #include "lltcp.h"
 
-LLtcp::~LLtcp () {}
-
 bool
 LLtcp::setup()
 {

--- a/src/libserver/lltcp.h
+++ b/src/libserver/lltcp.h
@@ -33,7 +33,7 @@ public:
     {
       t->setAuxName("TCP");
     }
-  virtual ~LLtcp ();
+  virtual ~LLtcp () = default;
 
   bool setup();
   void start();

--- a/src/libserver/lowlevel.cpp
+++ b/src/libserver/lowlevel.cpp
@@ -28,8 +28,6 @@ LowLevelAdapter::~LowLevelAdapter()
   delete iface;
 }
 
-LowLevelDriver::~LowLevelDriver() {}
-
 LowLevelIface::~LowLevelIface()
 {
   local_timeout.stop();

--- a/src/libserver/lowlevel.h
+++ b/src/libserver/lowlevel.h
@@ -145,7 +145,7 @@ public:
       master = parent;
     }
 
-  virtual ~LowLevelDriver ();
+  virtual ~LowLevelDriver () = default;
 
   virtual bool setup () { return true; }
   virtual void start () { started(); }

--- a/src/libserver/lpdu.cpp
+++ b/src/libserver/lpdu.cpp
@@ -193,18 +193,6 @@ L_Busmonitor_PDU::Decode (TracePtr t)
 
 /* L_Data */
 
-L_Data_PDU::L_Data_PDU () : LPDU()
-{
-  prio = PRIO_LOW;
-  repeated = 0;
-  valid_checksum = 1;
-  valid_length = 1;
-  AddrType = IndividualAddress;
-  source = 0;
-  dest = 0;
-  hopcount = 0x06;
-}
-
 bool
 L_Data_PDU::init (const CArray & c)
 {

--- a/src/libserver/lpdu.h
+++ b/src/libserver/lpdu.h
@@ -56,8 +56,8 @@ LPDU_Type;
 class LPDU
 {
 public:
-  LPDU () { }
-  virtual ~LPDU () { }
+  LPDU () = default;
+  virtual ~LPDU () = default;
 
   virtual bool init (const CArray & c) = 0;
   /** convert to a character array */
@@ -95,21 +95,22 @@ class L_Data_PDU:public LPDU
 {
 public:
   /** priority*/
-  EIB_Priority prio;
+  EIB_Priority prio = PRIO_LOW;
   /** is repreated */
-  bool repeated;
+  bool repeated = 0;
   /** checksum ok */
-  bool valid_checksum;
+  bool valid_checksum = 1;
   /** length ok */
-  bool valid_length;
+  bool valid_length = 1;
   /** to group/individual address*/
-  EIB_AddrType AddrType;
-  eibaddr_t source, dest;
-  uchar hopcount;
+  EIB_AddrType AddrType = IndividualAddress;
+  eibaddr_t source = 0;
+  eibaddr_t dest = 0;
+  uchar hopcount = 0x06;
   /** payload of Layer 4 */
   CArray data;
 
-  L_Data_PDU ();
+  L_Data_PDU () = default;
 
   bool init (const CArray & c);
   CArray ToPacket ();

--- a/src/libserver/router.cpp
+++ b/src/libserver/router.cpp
@@ -40,7 +40,7 @@ class RouterHigh : public Driver
   Router* router;
 public:
   RouterHigh(Router& r, const RouterLowPtr& rl);
-  virtual ~RouterHigh() {}
+  virtual ~RouterHigh() = default;
 
   virtual void recv_L_Data (LDataPtr l);
   virtual void recv_L_Busmonitor (LBusmonPtr l);
@@ -86,7 +86,7 @@ class RouterLow : public LinkConnect_
 public:
   Router* router;
   RouterLow(Router& r);
-  virtual ~RouterLow() {}
+  virtual ~RouterLow() = default;
 
   virtual void recv_L_Data (LDataPtr l) { router->queue_L_Data (std::move(l)); }
   virtual void recv_L_Busmonitor (LBusmonPtr l) { router->queue_L_Busmonitor (std::move(l)); }

--- a/src/libserver/tpdu.cpp
+++ b/src/libserver/tpdu.cpp
@@ -50,10 +50,6 @@ TPDU::fromPacket (const CArray & c, TracePtr tr)
 
 /* T_UNKNOWN  */
 
-T_UNKNOWN_PDU::T_UNKNOWN_PDU ()
-{
-}
-
 bool
 T_UNKNOWN_PDU::init (const CArray & c, TracePtr t UNUSED)
 {
@@ -81,10 +77,6 @@ String T_UNKNOWN_PDU::Decode (TracePtr t UNUSED)
 
 /* T_DATA_XXX_REQ  */
 
-T_DATA_XXX_REQ_PDU::T_DATA_XXX_REQ_PDU ()
-{
-}
-
 bool
 T_DATA_XXX_REQ_PDU::init (const CArray & c, TracePtr t UNUSED)
 {
@@ -111,11 +103,6 @@ String T_DATA_XXX_REQ_PDU::Decode (TracePtr t)
 }
 
 /* T_DATA_CONNECTED_REQ  */
-
-T_DATA_CONNECTED_REQ_PDU::T_DATA_CONNECTED_REQ_PDU ()
-{
-  serno = 0;
-}
 
 bool
 T_DATA_CONNECTED_REQ_PDU::init (const CArray & c, TracePtr t UNUSED)
@@ -148,10 +135,6 @@ String T_DATA_CONNECTED_REQ_PDU::Decode (TracePtr t)
 
 /* T_CONNECT_REQ  */
 
-T_CONNECT_REQ_PDU::T_CONNECT_REQ_PDU ()
-{
-}
-
 bool
 T_CONNECT_REQ_PDU::init (const CArray & c, TracePtr t UNUSED)
 {
@@ -173,10 +156,6 @@ String T_CONNECT_REQ_PDU::Decode (TracePtr t UNUSED)
 
 /* T_DISCONNECT_REQ  */
 
-T_DISCONNECT_REQ_PDU::T_DISCONNECT_REQ_PDU ()
-{
-}
-
 bool
 T_DISCONNECT_REQ_PDU::init (const CArray & c, TracePtr t UNUSED)
 {
@@ -197,11 +176,6 @@ String T_DISCONNECT_REQ_PDU::Decode (TracePtr t UNUSED)
 }
 
 /* T_ACK */
-
-T_ACK_PDU::T_ACK_PDU ()
-{
-  serno = 0;
-}
 
 bool
 T_ACK_PDU::init (const CArray & c, TracePtr t UNUSED)
@@ -228,11 +202,6 @@ String T_ACK_PDU::Decode (TracePtr t UNUSED)
 }
 
 /* T_NACK  */
-
-T_NACK_PDU::T_NACK_PDU ()
-{
-  serno = 0;
-}
 
 bool T_NACK_PDU::init (const CArray & c, TracePtr t UNUSED)
 {

--- a/src/libserver/tpdu.h
+++ b/src/libserver/tpdu.h
@@ -49,9 +49,7 @@ typedef std::unique_ptr<TPDU> TPDUPtr;
 class TPDU
 {
 public:
-  virtual ~TPDU ()
-  {
-  }
+  virtual ~TPDU () = default;
 
   virtual bool init (const CArray & c, TracePtr t) = 0;
   /** convert to character array */
@@ -69,7 +67,7 @@ class T_UNKNOWN_PDU:public TPDU
 public:
   CArray pdu;
 
-  T_UNKNOWN_PDU ();
+  T_UNKNOWN_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -84,7 +82,7 @@ class T_DATA_XXX_REQ_PDU:public TPDU
 public:
   CArray data;
 
-  T_DATA_XXX_REQ_PDU ();
+  T_DATA_XXX_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -97,10 +95,10 @@ public:
 class T_DATA_CONNECTED_REQ_PDU:public TPDU
 {
 public:
-  uchar serno;
+  uchar serno = 0;
   CArray data;
 
-  T_DATA_CONNECTED_REQ_PDU ();
+  T_DATA_CONNECTED_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -114,7 +112,7 @@ class T_CONNECT_REQ_PDU:public TPDU
 {
 public:
 
-  T_CONNECT_REQ_PDU ();
+  T_CONNECT_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -128,7 +126,7 @@ class T_DISCONNECT_REQ_PDU:public TPDU
 {
 public:
 
-  T_DISCONNECT_REQ_PDU ();
+  T_DISCONNECT_REQ_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -141,9 +139,9 @@ public:
 class T_ACK_PDU:public TPDU
 {
 public:
-  uchar serno;
+  uchar serno = 0;
 
-  T_ACK_PDU ();
+  T_ACK_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
   String Decode (TracePtr t);
@@ -156,9 +154,9 @@ public:
 class T_NACK_PDU:public TPDU
 {
 public:
-  uchar serno;
+  uchar serno = 0;
 
-  T_NACK_PDU ();
+  T_NACK_PDU () = default;
   bool init (const CArray & c, TracePtr t);
   CArray ToPacket ();
   String Decode (TracePtr t);

--- a/src/server/knxd_args.cpp
+++ b/src/server/knxd_args.cpp
@@ -124,8 +124,8 @@ public:
   /** The current tracer */
   std::vector < std::string > filters;
 
-  arguments () { }
-  virtual ~arguments () { }
+  arguments () = default;
+  virtual ~arguments () = default;
 
   /** get the current tracer.
    * Call with 'true' when you want to change the tracer


### PR DESCRIPTION
This is a recommendation from the C++ Core Guidelines:
C.45: Don't define a default constructor that only initializes data
members; use in-class member initializers instead

The "= default" might not even be necessary, but it shows that it's
intended to not define a constructor/destructor explicitly.

Signed-off-by: Tobias Lorenz <tobias.lorenz@gmx.net>