### PR TITLE
Fix compiler (gcc-9.2.1) warnings

### DIFF
--- a/src/backend/ft12.cpp
+++ b/src/backend/ft12.cpp
@@ -84,8 +84,6 @@ FT12Driver::make_EMI()
 bool
 FT12Driver::setup()
 {
-  FDdriver *fdd;
-
   iface = new FT12wrap(this, cfg);
 
   if (t->ShowPrint(0))

--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -100,10 +100,6 @@ TPUART::setup()
     return false;
 
   return true;
-ex1:
-  delete iface;
-  iface = nullptr;
-  return false;
 }
 
 bool

--- a/src/libserver/cemi.cpp
+++ b/src/libserver/cemi.cpp
@@ -68,7 +68,7 @@ void CEMIDriver::started()
   sendReset();
 }
 
-void CEMIDriver::reset_timer_cb(ev::timer &w, int revents)
+void CEMIDriver::reset_timer_cb(ev::timer &, int)
 {
   ERRORPRINTF(t, E_ERROR | 44, "reset timed out");
   errored();

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -564,7 +564,7 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       //FIXME: Hostname, MAC-addr
       memcpy(r2.MAC, mac_address, sizeof(r2.MAC));
       //FIXME: Hostname, indiv. address
-      strncpy ((char *) r2.name, servername.c_str(), sizeof(r2.name));
+      strncpy ((char *) r2.name, servername.c_str(), sizeof(r2.name) - 1);
       d.version = 1;
       d.family = 2; // core
       r2.services.push_back (d);
@@ -603,7 +603,7 @@ EIBnetServer::handle_packet (EIBNetIPPacket *p1, EIBNetIPSocket *isock)
       r2.multicastaddr = mcast->maddr.sin_addr;
       memcpy(r2.MAC, mac_address, sizeof(r2.MAC));
       //FIXME: Hostname, indiv. address
-      strncpy ((char *) r2.name, servername.c_str(), sizeof(r2.name));
+      strncpy ((char *) r2.name, servername.c_str(), sizeof(r2.name) - 1);
       d.version = 1;
       d.family = 2;
       if (discover)

--- a/src/libserver/emi2.cpp
+++ b/src/libserver/emi2.cpp
@@ -106,7 +106,7 @@ void EMI2Driver::started()
   sendReset();
 }
 
-void EMI2Driver::reset_timer_cb(ev::timer& w, int revents)
+void EMI2Driver::reset_timer_cb(ev::timer&, int)
 {
   ERRORPRINTF(t, E_ERROR | 57, "reset timed out");
   errored();

--- a/src/libserver/link.cpp
+++ b/src/libserver/link.cpp
@@ -146,7 +146,7 @@ LinkConnect::setState(LConnState new_state)
   state = new_state;
   TRACEPRINTF(t, 5, "%s => %s", osn, stateName());
 
-  if (old_state == L_wait_retry || old_state == L_up && new_state != L_up)
+  if (old_state == L_wait_retry || (old_state == L_up && new_state != L_up))
     retry_timer.stop();
 
   switch(old_state)
@@ -265,7 +265,7 @@ inval:
   return;
 
 retry:
-  if (retry_delay > 0 && !max_retries || retries < max_retries)
+  if ((retry_delay > 0 && !max_retries) || retries < max_retries)
     {
       TRACEPRINTF (t, 5, "retry in %d sec", retry_delay);
       state = L_wait_retry;

--- a/src/libserver/localserver.cpp
+++ b/src/libserver/localserver.cpp
@@ -52,7 +52,7 @@ LocalServer::start()
   struct sockaddr_un addr;
   TRACEPRINTF (t, 8, "OpenLocalSocket %s", path);
   addr.sun_family = AF_LOCAL;
-  strncpy (addr.sun_path, path.c_str(), sizeof (addr.sun_path));
+  strncpy (addr.sun_path, path.c_str(), sizeof (addr.sun_path) - 1);
 
   fd = socket (AF_LOCAL, SOCK_STREAM, 0);
   if (fd == -1)

--- a/src/libserver/router.cpp
+++ b/src/libserver/router.cpp
@@ -162,7 +162,6 @@ bool
 Router::setup()
 {
   std::string x;
-  const char *x2;
   IniSectionPtr s = ini[main];
   TRACEPRINTF (t, 4, "setting up");
 

--- a/src/server/knxd_args.cpp
+++ b/src/server/knxd_args.cpp
@@ -194,17 +194,17 @@ public:
         (*ini[section])[i->first] = i->second;
       more_args.clear();
       if (tracelevel >= 0 || errorlevel >= 0 || no_timestamps) {
-          char b1[10],b2[50];
+          char b1[12],b2[50];
           snprintf(b2,sizeof(b2),"debug-%s",section.c_str());
           (*ini[section])["debug"] = b2;
           if (tracelevel >= 0)
             {
-              snprintf(b1,sizeof(b1),"0x%x",tracelevel);
+              snprintf(b1,sizeof(b1) - 1,"0x%x",tracelevel);
               (*ini[b2])["trace-mask"] = b1;
             }
           if (errorlevel >= 0)
             {
-              snprintf(b1,sizeof(b1),"0x%x",errorlevel);
+              snprintf(b1,sizeof(b1) - 1,"0x%x",errorlevel);
               (*ini[b2])["error-level"] = b1;
             }
           if (no_timestamps)
@@ -452,11 +452,9 @@ parse_opt (int key, char *arg, struct argp_state *state)
         arguments->want_server = false;
         // (*ini["server"])["driver"] = "ets-link";
 
-        const char *serverip;
         const char *name = arguments->servername.c_str();
         std::string tracename;
 
-        int port = 0;
         char *a = strdup (OPT_ARG(arg, state, ""));
         char *b = strchr (a, ':');
         if (b)

--- a/src/tools/knxtool.c
+++ b/src/tools/knxtool.c
@@ -1188,10 +1188,11 @@ vbusmonitor1time\n");
 
       parseKey (&ac, &ag);
       if (ac < 7)
-	die
-	  ("usage: %s [-k key] url eibaddr obj prop start nr_of_elem [xx xx ..]",
-	   prog);
-        con = open_con(ag[1]);
+        {
+          die("usage: %s [-k key] url eibaddr obj prop start nr_of_elem "
+              "[xx xx ..]", prog);
+        }
+      con = open_con(ag[1]);
       dest = readaddr (ag[2]);
       obj = atoi (ag[3]);
       prop = atoi (ag[4]);

--- a/src/usb/usb.cpp
+++ b/src/usb/usb.cpp
@@ -45,10 +45,17 @@ USBLoop::USBLoop (TracePtr tr)
       return;
     }
 
+#if LIBUSB_API_VERSION >= 0x01000106
+  if(t->ShowPrint(10))
+    libusb_set_option(context, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
+  else
+    libusb_set_option(context, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_ERROR);
+#else
   if(t->ShowPrint(10))
     libusb_set_debug(context,LIBUSB_LOG_LEVEL_DEBUG);
   else
     libusb_set_debug(context,LIBUSB_LOG_LEVEL_ERROR);
+#endif
 
   tm.set<USBLoop, &USBLoop::timer_cb>(this);
   libusb_set_pollfd_notifiers (context, pollfd_added_cb,pollfd_removed_cb, this);


### PR DESCRIPTION
=== src/backend ===
ft12.cpp:87:13: warning: unused variable ‘fdd’ [-Wunused-variable]
tpuart.cpp:103:1: warning: label ‘ex1’ defined but not used [-Wunused-label]

=== src/libserver ===
cemi.cpp:71:44: warning: unused parameter ‘w’ [-Wunused-parameter]
cemi.cpp:71:51: warning: unused parameter ‘revents’ [-Wunused-parameter]
eibnetserver.cpp:567:15: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 30 equals destination size [-Wstringop-truncation]
eibnetserver.cpp:606:15: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 30 equals destination size [-Wstringop-truncation]
emi2.cpp:109:44: warning: unused parameter ‘w’ [-Wunused-parameter]
emi2.cpp:109:51: warning: unused parameter ‘revents’ [-Wunused-parameter]
link.cpp:149:54: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
link.cpp:268:23: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
localserver.cpp:55:11: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 108 equals destination size [-Wstringop-truncation]
router.cpp:165:15: warning: unused variable ‘x2’ [-Wunused-variable]

=== src/server ===
knxd_args.cpp:202:23: note: ‘snprintf’ output between 4 and 11 bytes into a destination of size 10
knxd_args.cpp:202:43: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
knxd_args.cpp:207:23: note: ‘snprintf’ output between 4 and 11 bytes into a destination of size 10
knxd_args.cpp:207:43: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
knxd_args.cpp:455:21: warning: unused variable ‘serverip’ [-Wunused-variable]
knxd_args.cpp:459:13: warning: unused variable ‘port’ [-Wunused-variable]

=== src/tools ===
knxtool.c:1190:7: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
knxtool.c:1194:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’

=== src/usb ===
usb.cpp:49:52: warning: ‘void libusb_set_debug(libusb_context*, int)’ is deprecated: Use libusb_set_option instead [-Wdeprecated-declarations]
usb.cpp:51:52: warning: ‘void libusb_set_debug(libusb_context*, int)’ is deprecated: Use libusb_set_option instead [-Wdeprecated-declarations]

Signed-off-by: Tobias Lorenz <tobias.lorenz@gmx.net>