### PR TITLE
Fix for crashing when sending to USB interface

### DIFF
--- a/src/libserver/usblowlevel.cpp
+++ b/src/libserver/usblowlevel.cpp
@@ -154,6 +154,7 @@ detectUSBEndpoint (libusb_context *context, USBEndpoint e)
 USBLowLevelDriver::USBLowLevelDriver (LowLevelIface* p, IniSectionPtr& s) : LowLevelDriver(p,s)
 {
   t->setAuxName("usbL");
+  send_timeout = cfg->value("send-timeout", 1000);
   read_trigger.set<USBLowLevelDriver,&USBLowLevelDriver::read_trigger_cb>(this);
   write_trigger.set<USBLowLevelDriver,&USBLowLevelDriver::write_trigger_cb>(this);
   read_trigger.start();
@@ -475,7 +476,7 @@ USBLowLevelDriver::do_send()
     }
   libusb_fill_interrupt_transfer (sendh, dev, d.sendep, sendbuf,
                                   sizeof (sendbuf), usb_complete_send,
-                                  this, 1000);
+                                  this, send_timeout);
   int res = libusb_submit_transfer (sendh);
   if (res)
     {

--- a/src/libserver/usblowlevel.h
+++ b/src/libserver/usblowlevel.h
@@ -88,6 +88,7 @@ private:
   CArray out;
   /** transmit retry counter */
   int send_retry = 0;
+  int send_timeout = 1000;
 
   UState state = sNone;
   bool stopping = false;


### PR DESCRIPTION
I have a Gira USB interface, and are running knxd on a Raspberry Pi3.

Later versions of knxd have usually crashed within a few seconds after sending a packet to the USB interface, hence have not been usable for me at all.

I looked at #415 and #450, which suggested increasing send-timeout to 5000, but that did not fix the problem for me.

When I got around to debugging the issue I found that the USBLowLevelDriver did not use the configured value, but used a hard-coded value of 1000.

Changing this to using the timeout value from the config seems to work for me, at least knxd have run without any hiccups for a couple of days now.

Note that I have only tried using a configured send-timeout of 5000.