### PR TITLE
fix knxd.service using prefix

### DIFF
--- a/systemd/knxd.service.in
+++ b/systemd/knxd.service.in
@@ -4,7 +4,7 @@ After=network.target knxd.socket
 Requires=knxd.socket
 
 [Service]
-EnvironmentFile=@sysconfdir@/knxd.conf
+EnvironmentFile=@prefix@/etc/knxd.conf
 ExecStart=@exec_prefix@/bin/knxd $KNXD_OPTS
 User=knxd
 Group=knxd


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Fix path generation to get absolute prefixed path instead of invalid "${prefix}/etc" for knxd.service config file.