### PR TITLE
expand prefix variables in knxd.service

### DIFF
--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -2,6 +2,10 @@ if HAVE_SYSTEMD
 systemdsystemunit_DATA=knxd.service knxd.socket
 sysconf_DATA=knxd.conf
 systemdsysusers_DATA=sysusers.d/knxd.conf
+all: knxd.service.exp
+knxd.service.exp: knxd.service
+	$(SED) -e 's,[$$]{prefix},$(prefix),g' -e 's,[$$]{exec_prefix},$(exec_prefix),g' < $< > $@
+	cp -p $@ $<
 endif
 
 EXTRA_DIST=knxd.conf sysusers.d/knxd.conf

--- a/systemd/knxd.service.in
+++ b/systemd/knxd.service.in
@@ -5,7 +5,7 @@ Requires=knxd.socket
 
 [Service]
 EnvironmentFile=@sysconfdir@/knxd.conf
-ExecStart=@exec_prefix@/bin/knxd $KNXD_OPTS
+ExecStart=@bindir@/knxd $KNXD_OPTS
 User=knxd
 Group=knxd
 Type=notify


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

support bindir and sysconfdir defintions in knxd.service.in

From the autoconf documentation:
GNU Coding Standards mandates that directory output variables are kept unexpanded by autoconf. This enables make to use a different prefix than the one defined with the configure command.
For the knxd.service file, an extra step with make is needed to replace prefix variables with their values when they remain after the configure step.

This patch allows using configure with --prefix and also with --bindir and --sysconfdir to set paths in knxd.service or just using the default prefix /usr/local