### PR TITLE
Add SATEL new KNX-USB interface to udev rules file

### DIFF
--- a/debian/knxd.udev
+++ b/debian/knxd.udev
@@ -58,5 +58,7 @@ ATTR{idVendor}=="145c", ATTR{idProduct}=="1330",OWNER="knxd",MODE="0600"
 ATTR{idVendor}=="147b", ATTR{idProduct}=="5120",OWNER="knxd",MODE="0600"
 # MDT SCN-USBR.01
 ATTR{idVendor}=="16d0", ATTR{idProduct}=="0491",OWNER="knxd",MODE="0600"
+# SATEL Sp. z o.o.: KNX-USB Interface
+ATTR{idVendor}=="24d5", ATTR{idProduct}=="0106",OWNER="knxd",MODE="0600"
 
 LABEL="knxd_end"


### PR DESCRIPTION
This adds a new KNX-USB converter from SATEL to udev rules file.
Here is the link to the product: https://www.satel.pl/en/produktid/1048
SATEL Sp. z o.o. is not on the debian linux VID list, but I confirmed that their VID is 24d5 here:
https://www.usb.org/sites/default/files/vendor_ids082119_0.pdf