### PR TITLE
Fix memory leak in FT 1.2

### DIFF
--- a/src/backend/ft12.cpp
+++ b/src/backend/ft12.cpp
@@ -377,10 +377,9 @@ FT12wrap::process_read(bool is_timeout)
           else if (akt[4] == (recvflag ? 0xD3 : 0xF3))
             {
               recvflag = !recvflag;
-              CArray *c = new CArray;
-              c->setpart (akt.data() + 5, 0, len - 7);
-              last = *c;
-              LowLevelFilter::recv_Data (*c);
+              CArray c(akt.data() + 5, 0, len - 7);
+              last = c;
+              LowLevelFilter::recv_Data (c);
             }
           akt.deletepart (0, len);
         }


### PR DESCRIPTION
Creation on the heap is not necessary here and causes a memory leak. Create the message on the stack rather.