### PR TITLE
fixed segfault on Openwrt for ramips platform

### DIFF
--- a/src/libserver/usblowlevel.cpp
+++ b/src/libserver/usblowlevel.cpp
@@ -155,6 +155,7 @@ USBLowLevelDriver::USBLowLevelDriver (LowLevelIface* p, IniSectionPtr& s) : LowL
 {
   t->setAuxName("usbL");
   send_timeout = cfg->value("send-timeout", 1000);
+  loop = nullptr;
   read_trigger.set<USBLowLevelDriver,&USBLowLevelDriver::read_trigger_cb>(this);
   write_trigger.set<USBLowLevelDriver,&USBLowLevelDriver::write_trigger_cb>(this);
   read_trigger.start();


### PR DESCRIPTION
initialize the loop variable to avoid segfault in USBLowLevelDriver::start()
