### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Check [the Wiki page](https://github.com/knxd/knxd/wiki) for other version(s) to
 On Debian/Ubuntu:
 
     sudo apt-get install git-core
+    sudo apt-get install -y libev4 libfmt7 libusb-1.0-0
 
     # get the source code
     git clone -b debian https://github.com/knxd/knxd.git


### PR DESCRIPTION
apt-get install -y libev4 libfmt7 libusb-1.0-0 added.
In buster, libfmt7 does not exist, so it will not work. 
In bullseye this works

I do not know how to fix it for buster, so I am not sure, this is the best fix.