### PR TITLE
Add back groupsocketwrite into knxtool

### DIFF
--- a/src/tools/knxtool.c
+++ b/src/tools/knxtool.c
@@ -881,6 +881,24 @@ end:
         die ("Request failed");
       printf ("Send request\n");
     }
+  else if (strcmp (prog, "groupsocketswrite") == 0)
+    {
+      uint8_t lbuf[3] = { 0x0, 0x80 };
+
+      if (ac != 4)
+        die ("usage: %s url eibaddr val", prog);
+      con = open_con(ag[1]);
+      dest = readgaddr (ag[2]);
+      lbuf[1] |= readHex (ag[3]) & 0x3f;
+
+      if (EIBOpen_GroupSocket (con, 1) == -1)
+        die ("Connect failed");
+
+      len = EIBSendGroup (con, dest, 2, lbuf);
+      if (len == -1)
+        die ("Request failed");
+      printf ("Send request\n");
+    }
   else if (strcmp (prog, "groupsresponse") == 0)
     {
       uint8_t lbuf[3] = { 0x0, 0x40 };

--- a/src/tools/knxtool.c
+++ b/src/tools/knxtool.c
@@ -862,6 +862,25 @@ end:
         die ("Request failed");
       printf ("Send request\n");
     }
+  else if (strcmp (prog, "groupsocketwrite") == 0)
+    {
+      buf[0] = 0x0;
+      buf[1] = 0x80;
+
+      if (ac < 4)
+        die ("usage: %s url eibaddr val val ...", prog);
+      con = open_con(ag[1]);
+      dest = readgaddr (ag[2]);
+      len = readBlock (buf + 2, sizeof (buf) - 2, ac - 3, ag + 3);
+
+      if (EIBOpen_GroupSocket (con, 1) == -1)
+        die ("Connect failed");
+
+      len = EIBSendGroup (con, dest, 2 + len, buf);
+      if (len == -1)
+        die ("Request failed");
+      printf ("Send request\n");
+    }
   else if (strcmp (prog, "groupsresponse") == 0)
     {
       uint8_t lbuf[3] = { 0x0, 0x40 };


### PR DESCRIPTION
`knxtool groupsocketwrite` was throwing an error because of a non-existing command, even though `knxtool list` indeed showed `groupsocketwrite` as a possible command.