### PR TITLE
knxd_args: rename link to knx_link to avoid conflict

### DIFF
--- a/src/server/knxd_args.cpp
+++ b/src/server/knxd_args.cpp
@@ -68,13 +68,13 @@ struct L2options
 } while(0)
 
 IniData ini;
-char link[99] = "@.";
+char knx_link[99] = "@.";
 void link_to(const char *arg)
 {
   char *p;
-  ++*link;
-  strcpy(link+2,arg);
-  p = strchr(link+2,':');
+  ++*knx_link;
+  strcpy(knx_link+2,arg);
+  p = strchr(knx_link+2,':');
   if (p)
     *p = 0;
 }
@@ -163,10 +163,10 @@ public:
       {
         link_to(name);
         ITER(i, more_args)
-        (*ini[link])[i->first] = i->second;
-        (*ini[link])["filter"] = name;
+        (*ini[knx_link])[i->first] = i->second;
+        (*ini[knx_link])["filter"] = name;
         more_args.clear();
-        filters.push_back(link);
+        filters.push_back(knx_link);
       }
     else
       filters.push_back(name);
@@ -232,7 +232,7 @@ void driver_argsv(const char *arg, char *ap, ...)
 {
   va_list apl;
   va_start(apl, ap);
-  (*ini[link])["driver"] = arg;
+  (*ini[knx_link])["driver"] = arg;
   char *pa = NULL;
 
   while(ap)
@@ -250,7 +250,7 @@ void driver_argsv(const char *arg, char *ap, ...)
       if (*pa == '!') // required-argument flag
         pa++;
       if (*ap) // skip empty arguments
-        (*ini[link])[pa] = ap;
+        (*ini[knx_link])[pa] = ap;
       ap = p2;
     }
   if (pa != NULL)
@@ -280,7 +280,7 @@ void driver_args(const char *arg, char *ap)
   else if(!strcmp(arg,"iptn"))
     {
       driver_argsv("ipt",ap, "!ip-address","dest-port","src-port","nat-ip","data-port", NULL);
-      (*ini[link])["nat"] = "true";
+      (*ini[knx_link])["nat"] = "true";
     }
   else if(!strcmp(arg,"ft12") || !strcmp(arg,"ncn5120") || !strcmp(arg,"tpuarts") || !strcmp(arg,"ft12cemi") || !strcmp(arg,"tpuart"))
     {
@@ -556,18 +556,18 @@ parse_opt (int key, char *arg, struct argp_state *state)
       if (arguments->want_server)
         die("You need -S after -D/-T/-R");
       link_to("unix");
-      ADD((*ini["main"])["connections"], link);
-      (*ini[link])["server"] = "knxd_unix";
-      // (*ini[link])["driver"] = "knx-link";
+      ADD((*ini["main"])["connections"], knx_link);
+      (*ini[knx_link])["server"] = "knxd_unix";
+      // (*ini[knx_link])["driver"] = "knx-link";
       const char *name = OPT_ARG(arg,state,NULL);
       if (name)
         {
-          (*ini[link])["path"] = name;
-          (*ini[link])["systemd-ignore"] = "false";
+          (*ini[knx_link])["path"] = name;
+          (*ini[knx_link])["systemd-ignore"] = "false";
         }
       else
-        (*ini[link])["systemd-ignore"] = "true";
-      arguments->stack(link);
+        (*ini[knx_link])["systemd-ignore"] = "true";
+      arguments->stack(knx_link);
     }
     break;
 
@@ -576,19 +576,19 @@ parse_opt (int key, char *arg, struct argp_state *state)
       if (arguments->want_server)
         die("You need -S after -D/-T/-R");
       link_to("tcp");
-      ADD((*ini["main"])["connections"], link);
-      (*ini[link])["server"] = "knxd_tcp";
-      // (*ini[link])["driver"] = "knx-link";
+      ADD((*ini["main"])["connections"], knx_link);
+      (*ini[knx_link])["server"] = "knxd_tcp";
+      // (*ini[knx_link])["driver"] = "knx-link";
       const char *port = OPT_ARG(arg,state,"");
       if (*port && atoi(port) > 0)
         {
-          (*ini[link])["port"] = port;
-          (*ini[link])["systemd-ignore"] = "false";
+          (*ini[knx_link])["port"] = port;
+          (*ini[knx_link])["systemd-ignore"] = "false";
         }
       else
-        (*ini[link])["systemd-ignore"] = "true";
+        (*ini[knx_link])["systemd-ignore"] = "true";
 
-      arguments->stack(link);
+      arguments->stack(knx_link);
     }
     break;
 
@@ -635,8 +635,8 @@ parse_opt (int key, char *arg, struct argp_state *state)
         die("You cannot apply flags to the group cache.");
 
       link_to("cache");
-      (*ini["main"])["cache"] = link;
-      arguments->stack(link);
+      (*ini["main"])["cache"] = knx_link;
+      arguments->stack(knx_link);
       break;
     case OPT_FORCE_BROADCAST:
       (*ini["main"])["force-broadcast"] = "true";
@@ -675,12 +675,12 @@ parse_opt (int key, char *arg, struct argp_state *state)
       if (arguments->want_server)
         die("You need -S after -D/-T/-R");
       link_to(arg);
-      ADD((*ini["main"])["connections"], link);
+      ADD((*ini["main"])["connections"], knx_link);
       char *ap = strchr(arg,':');
       if (ap)
         *ap++ = '\0';
       driver_args(arg,ap);
-      arguments->stack(link);
+      arguments->stack(knx_link);
       break;
     }
     case 'B':


### PR DESCRIPTION
The symbol link is defined by newer glibc versions as a function.
Rename it to knx_link to avoid the conflict.

Fixes #527

-- 

I went with knx_link instead of link2 since the number doesn't tell you anything and the knx at least tells you this is about the knx link. 