### PR TITLE
Fix EIB_Priority enum

### DIFF
--- a/src/libserver/lpdu.h
+++ b/src/libserver/lpdu.h
@@ -35,8 +35,8 @@
 enum EIB_Priority : uint8_t
 {
   PRIO_SYSTEM = 0,
-  PRIO_URGENT = 1,
-  PRIO_NORMAL = 2,
+  PRIO_NORMAL = 1,
+  PRIO_URGENT = 2,
   PRIO_LOW = 3
 };
 


### PR DESCRIPTION
According to KNX spec, PRIO_URGENT is 10b=2d and PRIO_NORMAL is 01b=1d.
Fixed EIB_Priority enum accordingly.