### PR TITLE
Add clang suport as build cc

### DIFF
--- a/m4/ccforbuild.m4
+++ b/m4/ccforbuild.m4
@@ -69,7 +69,7 @@ cat >conftest.c <<EOF
 int
 main ()
 {
-  exit(0);
+  return 0;
 }
 EOF
 gmp_compile="$1 conftest.c"
@@ -143,7 +143,7 @@ AC_CACHE_CHECK([for build system executable suffix],
 int
 main ()
 {
-  exit (0);
+  return 0;
 }
 EOF
 for i in .exe ,ff8 ""; do


### PR DESCRIPTION
ccforbuild.m4 comes from gmp project (very old version).
Current version does not support clang due to using GCC exit()
builtin function. clang does not have exit() builtin function.

GMP project fixed this issue by the commit https://gmplib.org/repo/gmp/rev/beda46a3c10d

This patch backports "upstream" change (`exit(0)` relaced by
`return 0` in conftest.c)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>