### PR TITLE
Parity error on reset fix for TPUART devices in combination with FTDI ICs

### DIFF
--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -43,7 +43,7 @@ protected:
   void termios_settings (struct termios &t1)
   {
     t1.c_cflag = CS8 | CLOCAL | CREAD | PARENB;
-    t1.c_iflag = IGNBRK | INPCK | ISIG;
+    t1.c_iflag = IGNBRK | ISIG;
     t1.c_oflag = 0;
     t1.c_lflag = 0;
     t1.c_cc[VTIME] = 1;
@@ -64,7 +64,8 @@ TPUART::create_wrapper(LowLevelIface* parent, IniSectionPtr& s, LowLevelDriver* 
 FDdriver *
 TPUARTwrap::create_serial(LowLevelIface* parent, IniSectionPtr& s)
 {
-  return new TPUARTserial(parent,s);
+  fd_driver = new TPUARTserial(parent,s);
+  return fd_driver;
 }
 
 
@@ -358,6 +359,31 @@ TPUARTwrap::timer_cb(ev::timer &, int)
     }
 }
 
+int
+TPUARTwrap::enableInputParityCheck()
+{
+  struct termios t1;
+
+  TRACEPRINTF (t, 8, "Enabling input parity check on fd %d\n", fd_driver->get_fd());
+
+  if (tcgetattr (fd_driver->get_fd(), &t1))
+  {
+    ERRORPRINTF (t, E_ERROR | 70, "tcgetattr failed: %s", strerror(errno));
+    return -1;
+  }
+
+  t1.c_iflag = t1.c_iflag | INPCK;
+
+  if (tcsetattr (fd_driver->get_fd(), TCSANOW, &t1))
+  {
+    ERRORPRINTF (t, E_ERROR | 70, "tcsetattr failed: %s", strerror(errno));
+    return -2;
+  }
+
+  return 0;
+}
+
+
 void
 TPUARTwrap::in_check()
 {
@@ -444,7 +470,9 @@ TPUARTwrap::recv_Data(CArray &c)
           if (state == T_in_reset)
             {
               TRACEPRINTF (t, 8, "RESET_ACK");
-              setstate(T_in_setaddr);
+              if (enableInputParityCheck()>=0)
+                setstate(T_in_setaddr);
+              // else time out
             }
           else
             TRACEPRINTF (t, 8, "spurious RESET_ACK");

--- a/src/backend/tpuart.h
+++ b/src/backend/tpuart.h
@@ -109,6 +109,9 @@ public:
 protected:
   virtual FDdriver * create_serial(LowLevelIface* parent, IniSectionPtr& s);
 
+private:
+  FDdriver *fd_driver = NULL;
+  int enableInputParityCheck();
 };
 
 #endif

--- a/src/libserver/lowlevel.cpp
+++ b/src/libserver/lowlevel.cpp
@@ -233,3 +233,7 @@ HWBusDriver::setup()
   return true;
 }
 
+int FDdriver::get_fd()
+{
+  return fd;
+}

--- a/src/libserver/lowlevel.h
+++ b/src/libserver/lowlevel.h
@@ -281,6 +281,7 @@ public:
   bool setup();
   void start();
   void stop(bool err);
+  int get_fd();
 
 protected:
   /** device connection */


### PR DESCRIPTION
knxd fails on reset if a TPUART IC in combination with a FTDI IC (eg. 230X) is used.
The reason is that the TPUART IC pulls the data lines low during reset which is interpreted as parity error.
This issue is described here #403 and #505.

This patch disables the parity check during initialization and enables it after the reset is finished.
