### PR TITLE
add formatter for fmt >= 10.0.0

### DIFF
--- a/src/backend/fpace.cpp
+++ b/src/backend/fpace.cpp
@@ -19,6 +19,9 @@
 
 #include "fpace.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(PSTATE t) { return t; }
+
 PaceFilter::PaceFilter (const LinkConnectPtr_& c, IniSectionPtr& s) : Filter(c,s)
 {
   last_len=0;

--- a/src/backend/fqueue.cpp
+++ b/src/backend/fqueue.cpp
@@ -19,6 +19,9 @@
 
 #include "fqueue.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(QSTATE t) { return t; }
+
 QueueFilter::QueueFilter (const LinkConnectPtr_& c, IniSectionPtr& s) : Filter(c,s)
 {
   trigger.set<QueueFilter, &QueueFilter::trigger_cb>(this);

--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -31,6 +31,9 @@
 #include "log.h"
 #include "cm_tp1.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(LPDU_Type t) { return t; }
+
 class TPUARTserial : public LLserial
 {
 public:

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -35,6 +35,9 @@
 
 #include "emi.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(ConnType t) { return t; }
+
 EIBnetServer::EIBnetServer (BaseRouter& r, IniSectionPtr& s)
   : Server(r,s)
   , mcast(NULL)

--- a/src/libserver/eibusb.cpp
+++ b/src/libserver/eibusb.cpp
@@ -24,6 +24,9 @@
 #include "emi2.h"
 #include "usblowlevel.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(EMIVer t) { return t; }
+
 USBConverterInterface::USBConverterInterface (LowLevelIface * p, IniSectionPtr& s)
   : LowLevelFilter(p,s)
 {

--- a/src/libserver/emi_common.cpp
+++ b/src/libserver/emi_common.cpp
@@ -21,6 +21,9 @@
 
 #include "emi.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(E_state t) { return t; }
+
 EMIVer
 cfgEMIVersion(IniSectionPtr& s)
 {

--- a/src/libserver/retry.cpp
+++ b/src/libserver/retry.cpp
@@ -19,6 +19,9 @@
 
 #include "retry.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(RSTATE t) { return t; }
+
 RetryFilter::RetryFilter (const LinkConnectPtr_& c, IniSectionPtr& s) : Filter(c,s)
 {
   trigger.set<RetryFilter, &RetryFilter::trigger_cb>(this);

--- a/src/libserver/usblowlevel.cpp
+++ b/src/libserver/usblowlevel.cpp
@@ -28,6 +28,10 @@
 
 #include "usb.h"
 
+/* add formatter for fmt >= 10.0.0 */
+int format_as(UState t) { return t; }
+int format_as(libusb_transfer_status t) { return t; }
+
 USBEndpoint
 parseUSBEndpoint (IniSectionPtr s)
 {


### PR DESCRIPTION
compilation of knxd fails using fmt >= 10.0.0 unless these formatters are added

from changelog of fmt:
Removed deprecated implicit conversions for enums and conversions to primitive types for compatibility with std::format and to prevent potential ODR violations. Use format_as instead.