### PR TITLE
Fix NCN5120 driver segmentation fault

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,44 +1,67 @@
 Alphabetical list of surnames of everyone who ever committed to this repository.
 Auto-generated from tools/list_AUTHORS and .mailmap
 
+dimnij <63244636+dimnij@users.noreply.github.com>
+akellai <akellai@users.noreply.github.com>
 Michael Albert <info@michlstechblog.info>
 Enrik Berkhan <Enrik.Berkhan@inka.de>
 bmxp <Bernd.Meiners@mail.de>
+HeySora <contact@heysora.net>
 Thomas Dallmair <dallmair@users.noreply.github.com>
+Tobias Deiminger <tobias.deiminger@posteo.de>
+Matthias Fechner <idefix@fechner.net>
 Meik Felser <mfmailbox-bcusdk@yahoo.de>
 Sven Fischer <sven@leiderfischer.de>
 Andreas Frisch <fraxinas@opendreambox.org>
 Eduard Fuchs <itfuchs@gmail.com>
 StalderT <github@netsolux.ch>
+Simón Golpe <33048138+Golpe82@users.noreply.github.com>
+Marcus Haehnel <marcus@mh-development.info>
 hari2 <hari@vt100.at>
 Richard Hartmann <richih@debian.org>
+Richard Hartmann <RichiH@users.noreply.github.com>
+henfri <hendrik@friedels.name>
 Stefan Hoffmeister <stefan@hoffmeister.biz>
+Matthias <idefix@fechner.net>
 J-N-K <jan.n.klug@rub.de>
 Marc Joliet <marcec@gmx.de>
+jrester <jrester379@gmail.com>
 jsauermann <juergen.sauermann@t-online.de>
 Elias Karakoulakis <elias.karakoulakis@gmail.com>
+Michael Kefeder <mike@multiwave.ch>
 Michael Kefeder <m.kefeder@gmail.com>
+Trond Kjeldås <trond@kjeldas.no>
 Trond Kjeldås <trond@kjeldas.no>
 Claus Klingberg <cjk@pobox.com>
 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+Gregor Krmelj <gregor@krmelj.xyz>
 Ole Krüger <ole.krueger@campus.tu-berlin.de>
 Harald <leithner@itronic.at>
+Harald Leithner <leithner@itronic.at>
 Tobias Lorenz <tobias.lorenz@gmx.net>
+MagicBear <magicbearmo@gmail.com>
 Michael Markstaller <michael@markstaller.de>
+Michael Markstaller <mm@elabnet.de>
 Joerg Mattiello <dev@mjoe.org>
 Race666 <michael@albert-hetzles.de>
 Sebastian <Morg42@users.noreply.github.com>
+akellai <no-reply>
 Ole <ole@vprsm.de>
 buergi <patbuergi@gmx.de>
 Patrik Pfaffenbauer <patrik.pfaffenbauer@p3.co.at>
 Joakim Plate <joakim.plate@gmail.com>
 Stephan Reinhard <Stephan-Reinhard@gmx.de>
+root <root@a2.pi.smurf.noris.de>
+Richard Schleich <rs@noreya.tech>
 shakaraba <shakaraba@gmail.com>
 smaiLee <stefan@stwidmer.ch>
 SystemTera <st@ubuntu.beka-consulting.local>
 Henning Treu <henning.treu@googlemail.com>
 Othmar Truniger <github@truniger.ch>
 Matthias Urlichs <matthias@urlichs.de>
+Matthias Urlichs <smurf@smurf.noris.de>
+Matthias Urlichs <smurf@zot.intern.smurf.noris.de>
+Sergey V. Lobanov <sergey@lobanov.in>
 Christian Wicke <knx.christian@safersignup.com>
 Timo Wingender <github@timo-wingender.de>
-Matthias Fechner <idefix@fechner.net>
+Paweł Żabiełowicz <pzabielowicz@onplick.pl>

--- a/src/backend/ncn5120.cpp
+++ b/src/backend/ncn5120.cpp
@@ -72,7 +72,8 @@ NCN5120::create_wrapper(LowLevelIface* parent, IniSectionPtr& s, LowLevelDriver*
 FDdriver *
 NCN5120wrap::create_serial(LowLevelIface* parent, IniSectionPtr& s)
 {
-  return new NCN5120serial(parent,s);
+  fd_driver = new NCN5120serial(parent,s);
+  return fd_driver;
 }
 
 void NCN5120wrap::RecvLPDU (const uint8_t * data, int len)

--- a/src/backend/tpuart.h
+++ b/src/backend/tpuart.h
@@ -108,9 +108,9 @@ public:
 
 protected:
   virtual FDdriver * create_serial(LowLevelIface* parent, IniSectionPtr& s);
+  FDdriver *fd_driver = NULL;
 
 private:
-  FDdriver *fd_driver = NULL;
   int enableInputParityCheck();
 };
 


### PR DESCRIPTION
I have been playing around with a Raspberry Pi and an OnSemi NCN5121 evaluation board. I was using the _debian_ branch since I was using the Raspberry Pi OS. The version I was using was `0.14.54-1`. Recently I tried building the main branch (version `0.14.59`) and I noticed that with the same config I was getting a segmentation fault. The same happened when building the latest _debian_ branch.

Using gdb I narrowed it down to the `FDdriver::get_fd` call probably returning NULL.
![Screenshot 2023-10-03 at 9 09 58 PM](https://github.com/knxd/knxd/assets/14580434/d091b633-8e2e-4c1a-a308-9c368b83ca6e)

[Checking the diff](https://github.com/knxd/knxd/compare/d87f5a1..663ce6e?diff=split
) between the release versions, I noticed that the TPUART driver was changed to include a pointer to the driver. Since the NCN5120 driver is based on the TPUART driver the solution to fix the fault was obvious.

I can confirm after applying this fix, the NCN5120 driver works as expected.

I followed the [contributions](https://github.com/knxd/knxd#contributions) section. Considering the number of changes in the AUTHORS file, it appears that the `tools/list_AUTHORS > AUTHORS` command hasn't been run in some time.

Thank you for this amazing project. Respect.