### PR TITLE
Fix `--Interface` not listening to specified interface

### DIFF
--- a/src/backend/eibnetrouter.cpp
+++ b/src/backend/eibnetrouter.cpp
@@ -16,6 +16,7 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+#include <net/if.h>
 #include <sys/socket.h>
 
 #include "eibnetrouter.h"
@@ -33,7 +34,7 @@ void
 EIBNetIPRouter::start()
 {
   struct sockaddr_in baddr;
-  struct ip_mreq mcfg;
+  struct ip_mreqn mcfg;
   TRACEPRINTF (t, 2, "Open");
   memset (&baddr, 0, sizeof (baddr));
 #ifdef HAVE_SOCKADDR_IN_LEN
@@ -62,7 +63,8 @@ EIBNetIPRouter::start()
   sock->localaddr.sin_port = sock->sendaddr.sin_port;
 
   mcfg.imr_multiaddr = sock->sendaddr.sin_addr;
-  mcfg.imr_interface.s_addr = htonl (INADDR_ANY);
+  mcfg.imr_address.s_addr = htonl (INADDR_ANY);
+  mcfg.imr_ifindex = if_nametoindex(interface.c_str());
   if (!sock->SetMulticast (mcfg))
     goto err_out;
   TRACEPRINTF (t, 2, "Opened");

--- a/src/libserver/eibnetip.cpp
+++ b/src/libserver/eibnetip.cpp
@@ -199,7 +199,7 @@ EIBNetIPSocket::port ()
 }
 
 bool
-EIBNetIPSocket::SetMulticast (struct ip_mreq multicastaddr)
+EIBNetIPSocket::SetMulticast (struct ip_mreqn multicastaddr)
 {
   if (multicast)
     return false;

--- a/src/libserver/eibnetip.h
+++ b/src/libserver/eibnetip.h
@@ -449,7 +449,7 @@ public:
   void stop(bool err);
 
   /** enables multicast */
-  bool SetMulticast (struct ip_mreq multicastaddr);
+  bool SetMulticast (struct ip_mreqn multicastaddr);
   /** sends a packet */
   void Send (EIBNetIPPacket p, struct sockaddr_in addr);
   void Send (EIBNetIPPacket p)
@@ -507,7 +507,7 @@ private:
   void send_q_drop();
 
   /** multicast address */
-  struct ip_mreq maddr;
+  struct ip_mreqn maddr;
   /** file descriptor */
   int fd;
   /** multicast in use? */

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -60,7 +60,7 @@ EIBnetDriver::EIBnetDriver (LinkConnectClientPtr c,
   : SubDriver(c)
 {
   struct sockaddr_in baddr;
-  struct ip_mreq mcfg;
+  struct ip_mreqn mcfg;
   sock = 0;
   t->setAuxName("driver");
 
@@ -99,7 +99,8 @@ EIBnetDriver::EIBnetDriver (LinkConnectClientPtr c,
     }
 
   mcfg.imr_multiaddr = maddr.sin_addr;
-  mcfg.imr_interface.s_addr = htonl (INADDR_ANY);
+  mcfg.imr_address.s_addr = htonl (INADDR_ANY);
+  mcfg.imr_ifindex = if_nametoindex(intf.c_str());
   if (!sock->SetMulticast (mcfg))
     goto err_out;
 


### PR DESCRIPTION
Calling IP_ADD_MEMBERSHIP with the ip_mreq struct and imr_address set to INADDR_ANY (0) results in the kernel deciding[0] which interface to use based on which interface has the default route and not any interface as one might expect.

This results in the `--Interface` option being nonfunctional unless the chosen interface also happens to be the one containing the default route. Multicast messages are sent to the correct interface as set by IP_MULTICAST_IF but everything sent to us is thrown away by the kernel since we're listening to a different interface.

To fix this, use the ip_mreqn struct instead and pass the interface number.

[0] https://github.com/torvalds/linux/blob/87adedeba51a822533649b143232418b9e26d08b/net/ipv4/igmp.c#L1827