### PR TITLE
Add default zero-HPAI when using NAT tunnel

### DIFF
--- a/src/backend/eibnettunnel.cpp
+++ b/src/backend/eibnettunnel.cpp
@@ -74,7 +74,7 @@ EIBNetIPTunnel::setup()
   monitor = cfg->value("monitor",false);
   if(NAT)
     {
-      srcip = cfg->value("nat-ip","");
+      srcip = cfg->value("nat-ip","0.0.0.0");
       dataport = cfg->value("data-port",0);
     }
   heartbeat_time = cfg->value("heartbeat-timer",30);


### PR DESCRIPTION
Default to zero HPAI when using a tunnel in NAT mode.

From the KNX Specifications v2.1 
03_08_02 Core v01.05.01 AS.pdf
> 8.6.3.5 Network Address Translation (NAT)
If KNXnet/IP communication has to traverse across network routers using Network Address Translation (NAT) the KNXnet/IP Client shall set the value of the IP address and/or the port number in the HPAI to zero to indicate NAT traversal to the receiving KNXnet/IP Server.
For the IP address and port number in the datagrams sent from the KNXnet/IP Server to the KNXnet/IP Client the KNXnet/IP Server shall replace the zero value for the IP address and/or the port number in the HPAI by the corresponding IP address and/or port number in the IP package received and use this value as the target IP address or port number for the response to the KNXnet/IP Client.