### PR TITLE
Set communication mode when initializing cEMI transport

### DIFF
--- a/src/libserver/cemi.h
+++ b/src/libserver/cemi.h
@@ -59,6 +59,7 @@ private:
   void sendLocal_done_cb(bool success);
 
   bool after_reset = false;
+  bool sent_comm_mode = false;
 
   ev::timer reset_timer;
   void reset_timer_cb(ev::timer &w, int revents);


### PR DESCRIPTION
According to the External Message Interface specification the client has to set the communication mode (see 4.2.2.4.2.1):

    After a power on or a reset, the cEMI Server device may be in an
    undefined communication mode. If the cEMI Client prior to any other
    communication to or from the bus does not set the Property
    Communication Mode, then the behaviour of the cEMI Server is
    undefined.

Update CEMIDriver to set the communication mode when initializing the cEMI transport by sending a M_PropWrite.req request to set the PID_COMM_MODE to 0x00 (which means Data Link Layer).

This commit should fix communication issues with some USB interfaces, in particular with the ABB USB/S1.2.

Fixes #517.

Probably also fixes #535 and #536.