### PR TITLE
Implement support for TCP tunnelling server

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -341,7 +341,7 @@ src/common/Makefile
 src/Makefile src/include/Makefile  src/client/Makefile src/examples/Makefile src/libserver/Makefile src/server/Makefile src/backend/Makefile
 src/client/def/Makefile src/client/c/Makefile src/client/java/Makefile src/client/php/Makefile src/client/cs/Makefile
 src/client/perl/Makefile src/client/python/Makefile src/client/pascal/Makefile src/client/ruby/Makefile src/client/lua/Makefile src/client/go/Makefile
-src/usb/Makefile src/tools/Makefile systemd/Makefile systemd/knxd.service systemd/knxd.socket
+src/usb/Makefile src/tools/Makefile systemd/Makefile systemd/knxd.service systemd/knxd.socket systemd/knxnetip.socket
 ])
 dnl src/tools/eibnet/Makefile src/tools/bcu/Makefile
 AC_OUTPUT

--- a/doc/inifile.rst
+++ b/doc/inifile.rst
@@ -872,6 +872,40 @@ On the command line, this server is typically used as "-DTRS". The
 -S|--Server argument has to be used last and accepted the options mentioned
 above.
 
+tcptunsrv
+----------
+
+The "tcptunserver" server allows clients to connect knxd using the KNXnet/ip
+TCP tunneling protocol.
+
+* tunnel (str)
+
+  This option names a section with configuration for tunnelled
+  connections. It's OK if that section doesn't exist or is empty.
+
+* port (int)
+
+  The TCP port to listen on / transmit to.
+
+  Optional; the default if neither port nor path are set is 3671.
+
+* path (string: file name)
+
+  Path to the socket file to use.
+
+  Optional; defaults to listening on a TCP port instead.
+
+* systemd-ignore (bool)
+
+  Ignore this server when knxd is started via systemd.
+
+  Optional; default "true" if listening on TCP port 3671.
+
+* heartbeat-timeout (integer: keep-alive timeout)
+
+  The maximum time between status messages from tunnel clients. A client
+  that doesn't send any packets for this long is disconnected.
+
 knxd_unix
 ---------
 

--- a/src/libserver/Makefile.am
+++ b/src/libserver/Makefile.am
@@ -42,7 +42,7 @@ SYSTEMD_SERVER =
 endif
 
 if HAVE_EIBNETSERVER
-EIBNETIP = eibnetserver.cpp eibnetserver.h
+EIBNETIP = eibnetserver.cpp eibnetserver.h tcptunserver.cpp tcptunserver.h tunchannel.cpp tunchannel.h
 else
 EIBNETIP =
 endif

--- a/src/libserver/client.cpp
+++ b/src/libserver/client.cpp
@@ -35,6 +35,10 @@
 #endif
 #include "server.h"
 
+ClientConnectionBase::~ClientConnectionBase ()
+{
+}
+
 ClientConnection::ClientConnection (NetServerPtr s, int fd) : router(static_cast<Router&>(s->router)), sendbuf(fd),recvbuf(fd)
 {
   t = TracePtr(new Trace(*(s->t)));

--- a/src/libserver/client.h
+++ b/src/libserver/client.h
@@ -39,12 +39,23 @@
 
 class A__Base;
 
-/** implements a client connection */
-class ClientConnection : public std::enable_shared_from_this<ClientConnection>
+/** a client connection, either for the knxd protocol or for tcp tunnelling */
+class ClientConnectionBase
 {
 public:
-  bool running = false;
+  virtual ~ClientConnectionBase ();
 
+  virtual bool setup() = 0;
+  virtual void start() = 0;
+  virtual void stop(bool err) = 0;
+
+  bool running = false;
+};
+
+/** implements a knxd protocol client connection */
+class ClientConnection : public ClientConnectionBase, public std::enable_shared_from_this<ClientConnection>
+{
+public:
   /** Layer 3 interface */
   Router &router;
   /** my address */

--- a/src/libserver/cm_ip.cpp
+++ b/src/libserver/cm_ip.cpp
@@ -27,12 +27,12 @@
 #include <unistd.h>
 
 CArray
-IPtoEIBNetIP (const struct sockaddr_in * a, bool nat)
+IPtoEIBNetIP (const struct sockaddr_in * a, bool nat, uint8_t protocol)
 {
   CArray buf;
   buf.resize (8);
   buf[0] = 0x08;
-  buf[1] = 0x01;
+  buf[1] = protocol;
   if (nat)
     {
       buf[2] = 0;
@@ -56,11 +56,11 @@ IPtoEIBNetIP (const struct sockaddr_in * a, bool nat)
 
 bool
 EIBnettoIP (const CArray & buf, struct sockaddr_in *a,
-            const struct sockaddr_in *src, bool & nat)
+            const struct sockaddr_in *src, bool & nat, uint8_t protocol)
 {
   int ip, port;
   memset (a, 0, sizeof (*a));
-  if (buf[0] != 0x8 || buf[1] != 0x1)
+  if (buf[0] != 0x8 || buf[1] != protocol)
     return true;
   ip = (buf[2] << 24) | (buf[3] << 16) | (buf[4] << 8) | (buf[5]);
   port = (buf[6] << 8) | (buf[7]);

--- a/src/libserver/cm_ip.h
+++ b/src/libserver/cm_ip.h
@@ -30,11 +30,11 @@
 #include "common.h"
 
 /** convert a to EIBnet/IP format */
-CArray IPtoEIBNetIP (const struct sockaddr_in *a, bool nat);
+CArray IPtoEIBNetIP (const struct sockaddr_in *a, bool nat, uint8_t protocol);
 
 /** convert EIBnet/IP IP Address to a */
 bool EIBnettoIP (const CArray & buf, struct sockaddr_in *a,
-                 const struct sockaddr_in *src, bool & nat);
+                 const struct sockaddr_in *src, bool & nat, uint8_t protocol);
 
 #endif
 

--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -35,9 +35,6 @@
 
 #include "emi.h"
 
-/* add formatter for fmt >= 10.0.0 */
-int format_as(ConnType t) { return t; }
-
 EIBnetServer::EIBnetServer (BaseRouter& r, IniSectionPtr& s)
   : Server(r,s)
   , mcast(NULL)

--- a/src/libserver/eibnetserver.h
+++ b/src/libserver/eibnetserver.h
@@ -50,6 +50,9 @@ enum ConnType
   CT_CONFIG,
 };
 
+/* add formatter for fmt >= 10.0.0 */
+inline int format_as(ConnType t) { return t; }
+
 /** Driver for tunnels */
 class ConnState: public SubDriver, public L_Busmonitor_CallBack
 {

--- a/src/libserver/tcptunserver.cpp
+++ b/src/libserver/tcptunserver.cpp
@@ -1,0 +1,698 @@
+/*
+    EIBD eib bus access and management daemon
+    Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "tcptunserver.h"
+#include "config.h"
+#include "tunchannel.h"
+
+#include <netinet/tcp.h>
+#include <sys/un.h>
+#include <arpa/inet.h>
+
+TcpTunConn::TcpTunConn(TcpTunServer *parent, uint32_t connectionID, int fd)
+  : t(TracePtr(new Trace(*parent->t)))
+  , sendbuf(fd)
+  , recvbuf(fd)
+  , connectionID(connectionID)
+  , fd(fd)
+{
+  this->parent = parent;
+
+  recvbuf.on_read.set<TcpTunConn, &TcpTunConn::read_cb>(this);
+  recvbuf.on_error.set<TcpTunConn, &TcpTunConn::error_cb>(this);
+  sendbuf.on_error.set<TcpTunConn, &TcpTunConn::error_cb>(this);
+
+  timeout.set<TcpTunConn,&TcpTunConn::timeout_cb>(this);
+  timeout.start(parent->keepalive, 0);
+
+  // Get address of local host
+  sockaddr_in localSocketAddress;
+  socklen_t len = sizeof(localSocketAddress);
+  if (getsockname(fd, (struct sockaddr *)&localSocketAddress, &len) != 0 ||
+      len != sizeof(localSocketAddress) ||
+      localSocketAddress.sin_family != AF_INET)
+    {
+      char str[64];
+      snprintf(str, sizeof(str), "stream-%d", connectionID);
+      t->setAuxName(str);
+    }
+  else
+    {
+      char addrStr[64];
+      if (inet_ntop(localSocketAddress.sin_family, &localSocketAddress.sin_addr, addrStr, sizeof(addrStr)))
+        {
+          char addrPortStr[64];
+          snprintf(addrPortStr, sizeof(addrPortStr), "%s:%d", addrStr, localSocketAddress.sin_port);
+          t->setAuxName(addrPortStr);
+        }
+      else
+        {
+          t->setAuxName("addr-error");
+        }
+    }
+}
+
+TcpTunConn::~TcpTunConn()
+{
+  TRACEPRINTF (t, 8, "Closing TcpTunConn");
+}
+
+void TcpTunConn::reset_timer()
+{
+  timeout.set(parent->keepalive, 0);
+}
+
+void
+TcpTunConn::error_cb()
+{
+  TRACEPRINTF (t, 8, "TcpTunConn communication error");
+  stop(true);
+}
+
+size_t
+TcpTunConn::read_cb(uint8_t *buf, size_t len)
+{
+  size_t done = 0;
+  for (;;) {
+    if (len < HEADER_SIZE_10)
+      return done;
+    if (buf[0] != HEADER_SIZE_10 || buf[1] != KNXNETIP_VERSION_10)
+      {
+        stop(true);
+        return done;
+      }
+    int tlen = (buf[4] << 8) | buf[5];
+    if (tlen > len)
+      return done;
+  
+    t->TracePacket(0, "TCP recv", tlen, buf);
+
+    CArray data(buf, tlen);
+    std::unique_ptr<EIBNetIPPacket> packet(EIBNetIPPacket::fromPacket(data, routeBackAddr(), IPV4_TCP));
+    if (!packet)
+      {
+        stop(true);
+        return done;
+      }
+
+    handlePacket(*packet);
+    done += tlen;
+    buf += tlen;
+    len -= tlen;
+  }
+}
+
+void TcpTunConn::timeout_cb(ev::timer &, int)
+{
+  TRACEPRINTF (t, 8, "Timeout for TCP connection");
+
+  stop(true);
+}
+
+int TcpTunConn::getFreeChannelID()
+{
+  uint8_t res = this->lastChannelID;
+
+  while (true)
+    {
+      res = (res + 1) & 0xff;
+
+      // Channel res is free
+      if (this->channels.find(res) == this->channels.end())
+        {
+          this->lastChannelID = res;
+          return res;
+        }
+
+      // No channel is free
+      if (res == this->lastChannelID)
+        {
+          return -1;
+        }
+    }
+}
+
+bool TcpTunConn::openChannel(const TunChannelPtr& channel)
+{
+  if (channels.find(channel->channelID) != channels.end())
+    {
+      TRACEPRINTF (t, 8, "Attempting to reuse open channel ID");
+      return false;
+    }
+
+  if (!channel->setupChannel())
+    {
+      TRACEPRINTF (t, 8, "Channel setup failed");
+      channel->stop(true);
+      return false;
+    }
+
+  this->channels[channel->channelID] = channel;
+
+  return true;
+}
+
+void TcpTunConn::closeChannel(const TunChannelPtr& channel)
+{
+  TRACEPRINTF (t, 8, "Closing channel %d", channel->channelID);
+
+  channel->stop(false);
+
+  this->channels.erase(channel->channelID);
+}
+
+TunChannelPtr TcpTunConn::findChannel(uint8_t channelID)
+{
+  auto it = this->channels.find(channelID);
+  if (it == this->channels.end())
+    return TunChannelPtr();
+  return it->second;
+}
+
+void TcpTunConn::stop(bool err)
+{
+  TRACEPRINTF (t, 8, "Stop Conn");
+
+  // Close all channels
+  while (true)
+    {
+      auto it = this->channels.begin();
+      if (it == this->channels.end())
+        break;
+      closeChannel(it->second);
+    }
+
+  sendbuf.stop();
+  recvbuf.stop();
+
+  close(fd);
+  fd = -1;
+
+  timeout.stop();
+
+  parent->deregister(shared_from_this());
+}
+
+void
+TcpTunConn::start()
+{
+  if (running)
+    return;
+  if (fd == -1)
+    return;
+
+  sendbuf.start();
+  recvbuf.start();
+
+  running = true;
+}
+
+bool TcpTunConn::setup()
+{
+  return true;
+}
+
+void
+TcpTunConn::send(const EIBNetIPPacket& p)
+{
+  CArray data = p.ToPacket();
+
+  t->TracePacket(0, "TCP send", data.size(), data.data());
+
+  if (fd >= 0)
+    sendbuf.write(data.data(), data.size());
+}
+
+void
+TcpTunConn::handlePacket(const EIBNetIPPacket &p1)
+{
+  if (p1.service == CONNECTIONSTATE_REQUEST)
+    {
+      EIBnet_ConnectionStateRequest r1;
+      EIBnet_ConnectionStateResponse r2;
+
+      if (parseEIBnet_ConnectionStateRequest(p1, r1))
+        {
+          t->TracePacket(2, "unparseable CONNECTIONSTATE_REQUEST", p1.data);
+          return;
+        }
+
+      reset_timer();
+
+      r2.channel = r1.channel;
+      auto channel = findChannel(r1.channel);
+      if (!channel)
+        {
+          r2.status = E_CONNECTION_ID;
+          send(r2.ToPacket(IPV4_TCP));
+          return;
+        }
+
+      TRACEPRINTF (t, 8, "CONNECTIONSTATE_REQUEST");
+
+      send(r2.ToPacket(IPV4_TCP));
+      return;
+    }
+
+  if (p1.service == DISCONNECT_REQUEST)
+    {
+      EIBnet_DisconnectRequest r1;
+      EIBnet_DisconnectResponse r2;
+      if (parseEIBnet_DisconnectRequest(p1, r1))
+        {
+          t->TracePacket (2, "unparseable DISCONNECT_REQUEST", p1.data);
+          return;
+        }
+
+      reset_timer();
+
+      r2.channel = r1.channel;
+      auto channel = findChannel(r1.channel);
+      if (!channel)
+        {
+          r2.status = E_CONNECTION_ID;
+          send(r2.ToPacket(IPV4_TCP));
+          return;
+        }
+
+      TRACEPRINTF (t, 8, "DISCONNECT_REQUEST");
+
+      closeChannel(channel);
+
+      r2.status = 0;
+      send(r2.ToPacket(IPV4_TCP));
+      return;
+    }
+
+  if (p1.service == CONNECTION_REQUEST)
+    {
+      EIBnet_ConnectRequest r1;
+      EIBnet_ConnectResponse r2;
+      // For TCP, the "Route Back" HPAI must be used.
+      // See ISO 22510:2019 section 5.2.8.6.2
+      r2.daddr = routeBackAddr();
+      if (parseEIBnet_ConnectRequest(p1, r1))
+        {
+          t->TracePacket(2, "unparseable CONNECTION_REQUEST", p1.data);
+          return;
+        }
+
+      reset_timer();
+
+      if (r1.CRI.size() == 3 && r1.CRI[0] == TUNNEL_CONNECTION)
+        {
+          int newChannelID = getFreeChannelID();
+          if (newChannelID < 0)
+          {
+            TRACEPRINTF (t, 8, "Out of channel IDs");
+            r2.status = E_NO_MORE_CONNECTIONS;
+            send(r2.ToPacket(IPV4_TCP));
+            return;
+          }
+
+          if (r1.CRI[1] == TUNNEL_LINKLAYER)
+            {
+              LinkConnectClientPtr link = LinkConnectClientPtr(new LinkConnectClient(std::dynamic_pointer_cast<TcpTunServer>(parent->shared_from_this()), parent->tunnel_cfg, t));
+
+              auto chan = std::make_shared<TunChannel>(shared_from_this(), newChannelID);
+              auto service = std::make_shared<TunServiceLinkLayer>(chan, static_cast<Router &>(parent->router), link);
+              chan->setService(service);
+
+              link->set_driver(service);
+
+              if (!link->setup())
+                {
+                  TRACEPRINTF (t, 8, "Tunnel CONNECTION_REQ link setup failed");
+                  r2.status = E_NO_MORE_CONNECTIONS;
+                  send(r2.ToPacket(IPV4_TCP));
+                  chan->stop(true);
+                  return;
+                }
+
+              if (!static_cast<Router &>(parent->router).registerLink(link, true))
+                {
+                  TRACEPRINTF (t, 8, "Tunnel CONNECTION_REQ registering link failed");
+                  r2.status = E_NO_MORE_CONNECTIONS;
+                  send(r2.ToPacket(IPV4_TCP));
+                  chan->stop(true);
+                  return;
+                }
+
+              // Allocate an address
+              if (!service->allocAddress())
+                {
+                  TRACEPRINTF (t, 8, "Tunnel CONNECTION_REQ no free addresses");
+                  r2.status = E_NO_MORE_CONNECTIONS;
+                  send(r2.ToPacket(IPV4_TCP));
+                  chan->stop(true);
+                  return;
+                }
+
+              if (openChannel(chan))
+                {
+                  r2.CRD.resize(3);
+                  r2.CRD[0] = TUNNEL_CONNECTION;
+                  TRACEPRINTF (t, 8, "Tunnel CONNECTION_REQ with %s", FormatEIBAddr(service->knxaddr));
+                  r2.CRD[1] = (service->knxaddr >> 8) & 0xFF;
+                  r2.CRD[2] = (service->knxaddr >> 0) & 0xFF;
+                  r2.status = E_NO_ERROR;
+                  r2.channel = chan->channelID;
+                }
+              else
+                r2.status = E_TUNNELING_LAYER;
+            }
+          else if (r1.CRI[1] == TUNNEL_BUSMONITOR)
+            {
+              r2.CRD.resize(3);
+              r2.CRD[0] = TUNNEL_CONNECTION;
+              r2.CRD[1] = 0;
+              r2.CRD[2] = 0;
+              auto chan = std::make_shared<TunChannel>(shared_from_this(), newChannelID);
+              chan->setService(std::make_shared<TunServiceBusMonitor>(chan, static_cast<Router &>(parent->router)));
+              if (openChannel(chan))
+                {
+                  r2.status = E_NO_ERROR;
+                  r2.channel = chan->channelID;
+                }
+              else
+                r2.status = E_TUNNELING_LAYER;
+            }
+          else
+            {
+              r2.status = E_TUNNELING_LAYER;
+              TRACEPRINTF (t, 8, "bad CONNECTION_REQ: [1] x%02x", r1.CRI[1]);
+              send(r2.ToPacket(IPV4_TCP));
+              return;
+            }
+        }
+      else if (r1.CRI.size() == 1 && r1.CRI[0] == DEVICE_MGMT_CONNECTION)
+        {
+          r2.CRD.resize(1);
+          r2.CRD[0] = DEVICE_MGMT_CONNECTION;
+          TRACEPRINTF (t, 8, "Tunnel CONNECTION_REQ, no addr (mgmt)");
+
+          int newChannelID = getFreeChannelID();
+          if (newChannelID < 0)
+          {
+            TRACEPRINTF (t, 8, "Out of channel IDs");
+            r2.status = E_NO_MORE_CONNECTIONS;
+            send(r2.ToPacket(IPV4_TCP));
+            return;
+          }
+
+          auto chan = std::make_shared<TunChannel>(shared_from_this(), newChannelID);
+          chan->setService(std::make_shared<TunServiceConfig>(chan));
+
+          if (openChannel(chan))
+            {
+              r2.status = E_NO_ERROR;
+              r2.channel = chan->channelID;
+            }
+          else
+            r2.status = E_TUNNELING_LAYER;
+        }
+      else
+        {
+          TRACEPRINTF (t, 8, "bad CONNECTION_REQ: size %d, [0] x%02x", r1.CRI.size(), r1.CRI[0]);
+          r2.status = E_CONNECTION_TYPE;
+        }
+
+      send(r2.ToPacket(IPV4_TCP));
+      return;
+    }
+
+  if (p1.service == TUNNEL_REQUEST)
+    {
+      EIBnet_TunnelRequest r1;
+      EIBnet_TunnelACK r2;
+      if (parseEIBnet_TunnelRequest(p1, r1))
+        {
+          t->TracePacket(2, "unparseable TUNNEL_REQUEST", p1.data);
+          return;
+        }
+
+      reset_timer();
+
+      auto channel = findChannel(r1.channel);
+      if (!channel)
+        {
+          TRACEPRINTF (t, 8, "TUNNEL_REQUEST on unknown channel %d", r1.channel);
+          r2.status = E_CONNECTION_ID;
+          send(r2.ToPacket(IPV4_TCP));
+          return;
+        }
+
+      channel->receiveTunnelRequest(r1);
+
+      return;
+    }
+
+  if (p1.service == DEVICE_CONFIGURATION_REQUEST)
+    {
+      EIBnet_ConfigRequest r1;
+      EIBnet_ConfigACK r2;
+      if (parseEIBnet_ConfigRequest(p1, r1))
+        {
+          t->TracePacket(2, "unparseable DEVICE_CONFIGURATION_REQUEST", p1.data);
+          return;
+        }
+
+      reset_timer();
+
+      auto channel = findChannel(r1.channel);
+      if (!channel)
+        {
+          TRACEPRINTF (t, 8, "DEVICE_CONFIGURATION_REQUEST on unknown channel %d", r1.channel);
+          r2.status = E_CONNECTION_ID;
+          send(r2.ToPacket(IPV4_TCP));
+          return;
+        }
+
+      TRACEPRINTF (t, 8, "CONFIG_REQ on channel %d",r1.channel);
+
+      channel->receiveConfigRequest(r1);
+
+      return;
+    }
+
+  TRACEPRINTF (t, 8, "Unexpected service type: %04x", p1.service);
+}
+
+TcpTunServer::TcpTunServer(BaseRouter& r, IniSectionPtr& s)
+  : NetServerBase(r,s)
+  , tunnel_cfg(s->sub("tunnel",false))
+{
+  t->setAuxName("tcptunsrv");
+}
+
+TcpTunServer::~TcpTunServer()
+{
+  if (fd >= 0)
+    close(fd);
+}
+
+bool
+TcpTunServer::setup()
+{
+  if (!Server::setup())
+    return false;
+  port = cfg->value("port", 3671);
+  path = cfg->value("path", "");
+  keepalive = cfg->value("heartbeat-timeout", CONNECTION_ALIVE_TIME);
+  ignore_when_systemd = cfg->value("systemd-ignore", (port == 3671 && path == ""));
+
+  /* Check that we have client addresses. */
+  if (!static_cast<Router&>(router).hasClientAddrs())
+    return false;
+  /* set up a temporary fake tunnel stack to test the arguments early. */
+  if (!static_cast<Router &>(router).checkStack(tunnel_cfg))
+    return false;
+
+  return true;
+}
+
+void
+TcpTunServer::start()
+{
+  int reuse = 1;
+
+  if (ignore_when_systemd && static_cast<Router &>(router).using_systemd)
+    {
+      ignore = true;
+      stopped(true);
+      return;
+    }
+
+  if (path == "")
+    {
+      // TCP
+      struct sockaddr_in addr;
+
+      TRACEPRINTF (t, 8, "OpenInetSocket %d", port);
+      memset(&addr, 0, sizeof (addr));
+      addr.sin_family = AF_INET;
+      addr.sin_port = htons(port);
+      addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+      fd = socket(AF_INET, SOCK_STREAM, 0);
+      if (fd == -1)
+        {
+          ERRORPRINTF (t, E_ERROR | 149, "OpenInetSocket %d: socket: %s", port, strerror(errno));
+          goto ex1;
+        }
+
+      setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof (reuse));
+
+      if (bind(fd, (struct sockaddr *) &addr, sizeof (addr)) == -1)
+        {
+          ERRORPRINTF (t, E_ERROR | 150, "OpenInetSocket %d: bind: %s", port, strerror(errno));
+          goto ex2;
+        }
+    }
+  else
+    {
+      // Unix domain socket
+      struct sockaddr_un addr;
+
+      TRACEPRINTF (t, 8, "OpenUnixSocket '%s'", path);
+      memset(&addr, 0, sizeof (addr));
+      addr.sun_family = AF_LOCAL;
+      strncpy(addr.sun_path, path.c_str(), sizeof (addr.sun_path) - 1);
+
+      fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+      if (fd == -1)
+        {
+          ERRORPRINTF (t, E_ERROR | 151, "OpenUnixSocket %d: socket: %s", port, strerror(errno));
+          goto ex1;
+        }
+
+      if (bind(fd, (struct sockaddr *) &addr, sizeof (addr)) == -1)
+        {
+          /*
+           * dead file?
+           */
+          if (errno == EADDRINUSE)
+            {
+              if (connect(fd, (struct sockaddr *) &addr, sizeof (addr)) == 0)
+                {
+ex:
+                  ERRORPRINTF (t, E_ERROR | 152, "OpenLocalSocket %s: bind: %s", path, strerror(errno));
+                  goto ex2;
+                }
+              else if (errno == ECONNREFUSED)
+                {
+                  ::unlink(path.c_str());
+                  if (bind(fd, (struct sockaddr *) &addr, sizeof (addr)) == -1)
+                    goto ex;
+                }
+              else
+                {
+                  ERRORPRINTF (t, E_ERROR | 153, "Existing socket %s: connect: %s", path, strerror(errno));
+                  goto ex2;
+                }
+            }
+        }
+    }
+
+  if (listen(fd, 10) == -1)
+    {
+      ERRORPRINTF (t, E_ERROR | 154, "OpenSocket: listen: %s", strerror(errno));
+      goto ex2;
+    }
+
+  TRACEPRINTF (t, 8, "Socket opened");
+  NetServerBase::start();
+  return;
+
+ex2:
+  close(fd);
+  fd = -1;
+ex1:
+  stop(true);
+  return;
+}
+
+void
+TcpTunServer::setupConnection(int cfd)
+{
+  int val = 1;
+  setsockopt(cfd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof (val));
+}
+
+ClientConnBasePtr
+TcpTunServer::createConnection(int cfd)
+{
+  auto connection = std::shared_ptr<TcpTunConn>(new TcpTunConn(this, ++lastConnectionID, cfd));
+
+  return connection;
+}
+
+void
+TcpTunServer::stop(bool err)
+{
+  if (fd >= 0)
+    {
+      close(fd);
+      fd = -1;
+    }
+  NetServerBase::stop(err);
+}
+
+TcpTunSystemdServer::TcpTunSystemdServer(BaseRouter& r, IniSectionPtr& s, int systemd_fd)
+  : TcpTunServer(r,s)
+{
+  t->setAuxName("systemd_tcptunsrv");
+  fd = systemd_fd;
+}
+
+void
+TcpTunSystemdServer::start()
+{
+  TRACEPRINTF (t, 8, "OpenSystemdSocket %d", fd);
+  if (fd < 0)
+    {
+      stopped(true);
+      return;
+    }
+
+  if (listen(fd, 10) == -1)
+    {
+      ERRORPRINTF (t, E_ERROR | 148, "OpenSystemdSocket: listen: %s", strerror(errno));
+      TcpTunServer::stop(true);
+      return;
+    }
+
+  TRACEPRINTF (t, 8, "SystemdSocket %d opened", fd);
+  NetServerBase::start();
+}
+
+void
+TcpTunSystemdServer::stop(bool err)
+{
+  TcpTunServer::stop(err);
+}
+
+TcpTunSystemdServer::~TcpTunSystemdServer()
+{
+  if (fd >= 0)
+    {
+      close(fd);
+      fd = -1;
+    }
+}

--- a/src/libserver/tcptunserver.h
+++ b/src/libserver/tcptunserver.h
@@ -1,0 +1,124 @@
+/*
+    EIBD eib bus access and management daemon
+    Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+/**
+ * @file
+ * @ingroup KNX_03_08_01
+ * KNXnet/IP
+ * @{
+ */
+
+#ifndef TCPTUN_SERVER_H
+#define TCPTUN_SERVER_H
+
+#include "eibnetip.h"
+#include "server.h"
+#include "client.h"
+
+class TunChannel;
+using TunChannelPtr = std::shared_ptr<TunChannel>;
+
+class TcpTunConn;
+using TcpTunConnPtr = std::shared_ptr<TcpTunConn>;
+
+class TcpTunServer;
+using TcpTunServerPtr = std::shared_ptr<TcpTunServer>;
+
+/** Driver for tunnels */
+class TcpTunConn : public ClientConnectionBase, public std::enable_shared_from_this<TcpTunConn>
+{
+public:
+  TcpTunConn(TcpTunServer *parent, uint32_t connectionID, int fd);
+  virtual ~TcpTunConn();
+  bool setup() override;
+  void start() override;
+  void stop(bool err) override;
+
+  TracePtr t;
+  TcpTunServer *parent;
+
+  ev::timer timeout;
+  void timeout_cb(ev::timer &w, int revents);
+  void reset_timer();
+
+  size_t read_cb(uint8_t *buf, size_t len);
+  void error_cb();
+
+  void handlePacket(const EIBNetIPPacket &p1);
+
+  // Return the next free channel ID, or -1 if no channels are available
+  int getFreeChannelID();
+  bool openChannel(const TunChannelPtr& channel);
+  void closeChannel(const TunChannelPtr& channel);
+  // Return the channel with ID channelID or nullptr if there is no such channel
+  TunChannelPtr findChannel(uint8_t channelID);
+
+  void send(const EIBNetIPPacket& p);
+
+protected:
+  uint32_t connectionID;
+
+  SendBuf sendbuf;
+  RecvBuf recvbuf;
+  int fd;
+
+  uint8_t lastChannelID = 0;
+  std::map<uint8_t, TunChannelPtr> channels;
+};
+
+SERVER_(TcpTunServer,NetServerBase,tcptunsrv)
+{
+  friend class TcpTunConn;
+
+public:
+  TcpTunServer(BaseRouter& r, IniSectionPtr& s);
+  virtual ~TcpTunServer();
+
+  bool setup() override;
+  void start() override;
+  void stop(bool err) override;
+
+  ClientConnBasePtr createConnection(int cfd) override;
+
+protected:
+  void setupConnection(int cfd) override;
+
+private:
+  uint32_t lastConnectionID = 0;
+
+  /** config */
+  uint16_t port;
+  std::string path;
+  ev::tstamp keepalive;
+  IniSectionPtr tunnel_cfg;
+};
+
+class TcpTunSystemdServer : public TcpTunServer
+{
+public:
+  TcpTunSystemdServer(BaseRouter& r, IniSectionPtr& s, int systemd_fd);
+  ~TcpTunSystemdServer() override;
+
+  void start() override;
+  void stop(bool err) override;
+};
+
+#endif
+
+/** @} */

--- a/src/libserver/tunchannel.cpp
+++ b/src/libserver/tunchannel.cpp
@@ -1,0 +1,401 @@
+/*
+    EIBD eib bus access and management daemon
+    Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "tunchannel.h"
+#include "tcptunserver.h"
+
+TunChannel::TunChannel(const TcpTunConnPtr& connection, uint8_t channelID)
+  : t(TracePtr(new Trace(*connection->t)))
+  , connection(connection)
+  , channelID(channelID)
+{
+  char buf[10];
+  snprintf(buf, sizeof(buf), "-%02x", channelID);
+  t->setAuxName(connection->t->auxname + buf);
+}
+
+TunChannel::~TunChannel()
+{
+  TRACEPRINTF (t, 8, "Close TunChannel");
+}
+
+void TunChannel::setService(const TunServicePtr& service)
+{
+  if (this->service)
+    {
+      TRACEPRINTF (t, 8, "Service is already set");
+      return;
+    }
+
+  TRACEPRINTF (t, 8, "Setting service");
+
+  this->service = service;
+}
+
+bool TunChannel::setupChannel()
+{
+  if (!this->service)
+    {
+      TRACEPRINTF (t, 8, "Service not set");
+      return false;
+    }
+
+  return service->setupService();
+}
+
+void TunChannel::start()
+{
+  service->start();
+}
+
+void TunChannel::stop(bool err)
+{
+  service->stop(err);
+}
+
+void TunChannel::sendTunnelRequest(const CArray& cemi)
+{
+  auto connection = this->connection.lock();
+  if (!connection)
+    {
+      TRACEPRINTF (t, 8, "Attempt to send tunnel request without a connection");
+      return;
+    }
+
+  EIBnet_TunnelRequest r;
+  r.channel = channelID;
+  r.seqno = sno;
+  r.CEMI = cemi;
+  connection->send(r.ToPacket(IPV4_TCP));
+  sno = (sno + 1) & 0xff;
+}
+
+void TunChannel::sendConfigRequest(const CArray& cemi)
+{
+  auto connection = this->connection.lock();
+  if (!connection)
+    {
+      TRACEPRINTF (t, 8, "Attempt to send config request without a connection");
+      return;
+    }
+
+  EIBnet_ConfigRequest r;
+  r.channel = channelID;
+  r.seqno = sno;
+  r.CEMI = cemi;
+  connection->send(r.ToPacket(IPV4_TCP));
+  sno = (sno + 1) & 0xff;
+}
+
+void TunChannel::receiveTunnelRequest(EIBnet_TunnelRequest &r1)
+{
+  // On UDP, the sequence number would be checked here, but for TCP the sequence
+  // number is not checked. See ISO 22510:2019 section 5.2.5.3.4
+  // if (rno != r1.seqno)
+  //   {
+  //     TRACEPRINTF (t, 8, "Wrong tunnel sequence number %d<->%d",
+  //                  r1.seqno, rno);
+  //   }
+  rno++;
+
+  if (!service)
+    {
+      TRACEPRINTF (t, 8, "No tunnel service set");
+      return;
+    }
+
+  uint8_t status = service->handleTunnelRequest(r1);
+
+  // Note: There are no TUNNELLING_ACKs with TCP, so no way to return the status
+  if (status)
+    TRACEPRINTF (t, 8, "TCP TUNNELLING_REQUEST failed (%d)", status);
+}
+
+void TunChannel::receiveConfigRequest(EIBnet_ConfigRequest &r1)
+{
+  // On UDP, the sequence number would be checked here, but for TCP the sequence
+  // number is not checked. See ISO 22510:2019 section 5.2.5.3.4
+  // if (rno != r1.seqno)
+  //   {
+  //     TRACEPRINTF (t, 8, "Wrong config sequence number %d<->%d",
+  //                  r1.seqno, rno);
+  //   }
+  rno++;
+
+  if (!service)
+    {
+      TRACEPRINTF (t, 8, "No tunnel service set");
+      return;
+    }
+
+  uint8_t status = service->handleConfigRequest(r1);
+
+  // Note: There are no DEVICE_CONFIGURATION_ACKs with TCP, so no way to return
+  // the status
+  if (status)
+    TRACEPRINTF (t, 8, "TCP DEVICE_CONFIGURATION_REQUEST failed (%d)", status);
+}
+
+TunService::TunService(const TunChannelPtr& channel)
+  : t(channel->t)
+  , channel(channel)
+{
+}
+
+TunService::~TunService()
+{
+}
+
+// This method is overwritten on channel classes which expect to receive
+// TUNNELLING_REQUEST packets
+ErrorCode TunService::handleTunnelRequest(EIBnet_TunnelRequest &r1)
+{
+  TRACEPRINTF (t, 8, "Got unexpected TUNNELLING_REQUEST");
+  return E_TUNNELING_LAYER;
+}
+
+// This method is overwritten on channel classes which expect to receive
+// DEVICE_CONFIGURATION_REQUEST packets
+ErrorCode TunService::handleConfigRequest(EIBnet_ConfigRequest &r1)
+{
+  TRACEPRINTF (t, 8, "Got unexpected DEVICE_CONFIGURATION_REQUEST");
+  return E_KNX_CONNECTION;
+}
+
+TunServiceLinkLayer::TunServiceLinkLayer(const TunChannelPtr& channel, Router& router, LinkConnectClientPtr c)
+  : SubDriver(c)
+  , TunService(channel)
+  , router(router)
+{
+  SubDriver::t->setAuxName(channel->t->auxname);
+}
+
+TunServiceLinkLayer::~TunServiceLinkLayer()
+{
+}
+
+bool TunServiceLinkLayer::setupService()
+{
+  addAddress(knxaddr);
+
+  return true;
+}
+
+bool TunServiceLinkLayer::setup()
+{
+  if (!SubDriver::setup())
+    return false;
+
+  return true;
+}
+
+void TunServiceLinkLayer::start()
+{
+  SubDriver::start();
+}
+
+void TunServiceLinkLayer::stop(bool err)
+{
+  freeAddress();
+
+  auto c = std::dynamic_pointer_cast<LinkConnect>(conn.lock());
+  if (c != nullptr)
+    router.unregisterLink(c);
+
+  SubDriver::stop(err);
+}
+
+void TunServiceLinkLayer::send_L_Data (LDataPtr l)
+{
+  auto channel_ptr = this->channel.lock();
+  if (channel_ptr)
+    channel_ptr->sendTunnelRequest(L_Data_ToCEMI(0x29, l));
+
+  send_Next();
+}
+
+ErrorCode TunServiceLinkLayer::handleTunnelRequest(EIBnet_TunnelRequest &r1)
+{
+  TRACEPRINTF (t, 8, "TUNNEL_REQ");
+
+  LDataPtr c = CEMI_to_L_Data(r1.CEMI, t);
+  if (!c)
+    return E_DATA_CONNECTION;
+
+  if (c->source_address == 0)
+    c->source_address = knxaddr;
+
+  if (r1.CEMI[0] == 0x11)
+    {
+      // Send L_Data.con message
+      auto channel_ptr = this->channel.lock();
+      if (channel_ptr)
+        channel_ptr->sendTunnelRequest(L_Data_ToCEMI(0x2E, c));
+    }
+
+  if (r1.CEMI[0] == 0x11 || r1.CEMI[0] == 0x29)
+    {
+      recv_L_Data(std::move(c));
+      return E_NO_ERROR;
+    }
+  else
+    {
+      TRACEPRINTF (t, 8, "Wrong leader x%02x", r1.CEMI[0]);
+      return E_TUNNELING_LAYER;
+    }
+}
+
+bool TunServiceLinkLayer::allocAddress()
+{
+  // Channel can have only one address
+  if (knxaddr)
+    return false;
+
+  knxaddr = router.get_client_addr(t);
+  if (!knxaddr)
+    // Out of addresses
+    return false;
+
+  t->setAuxName(FormatEIBAddr(knxaddr));
+
+  return true;
+}
+
+void TunServiceLinkLayer::freeAddress()
+{
+  if (!knxaddr)
+    return;
+
+  router.release_client_addr(knxaddr);
+  knxaddr = 0;
+  t->setAuxName("no-addr");
+}
+
+TunServiceBusMonitor::TunServiceBusMonitor(const TunChannelPtr& channel, Router& router)
+  : TunService(channel)
+  , L_Busmonitor_CallBack(channel->t->name)
+  , router(router)
+{
+}
+
+TunServiceBusMonitor::~TunServiceBusMonitor()
+{
+}
+
+bool TunServiceBusMonitor::setupService()
+{
+  if (!router.registerVBusmonitor(this))
+    return false;
+
+  return true;
+}
+
+void TunServiceBusMonitor::start()
+{
+}
+
+void TunServiceBusMonitor::stop(bool err)
+{
+  router.deregisterVBusmonitor(this);
+}
+
+void TunServiceBusMonitor::send_L_Busmonitor(LBusmonPtr l)
+{
+  auto channel_ptr = this->channel.lock();
+  if (channel_ptr)
+    channel_ptr->sendTunnelRequest(Busmonitor_to_CEMI(0x2B, l, no));
+
+  no++;
+}
+
+TunServiceConfig::TunServiceConfig(const TunChannelPtr& channel)
+  : TunService(channel)
+{
+}
+
+TunServiceConfig::~TunServiceConfig()
+{
+}
+
+bool TunServiceConfig::setupService()
+{
+  return true;
+}
+
+void TunServiceConfig::start()
+{
+}
+
+void TunServiceConfig::stop(bool err)
+{
+}
+
+ErrorCode TunServiceConfig::handleConfigRequest(EIBnet_ConfigRequest &r1)
+{
+  if (r1.CEMI.size() == 0)
+    return E_DATA_CONNECTION;
+
+  if (r1.CEMI[0] == 0xFC) // M_PropRead.req
+    {
+      if (r1.CEMI.size() == 7)
+        {
+          CArray res, CEMI;
+          int obj = (r1.CEMI[1] << 8) | r1.CEMI[2];
+          int objno = r1.CEMI[3];
+          int prop = r1.CEMI[4];
+          int count = (r1.CEMI[5] >> 4) & 0x0f;
+          int start = (r1.CEMI[5] & 0x0f) | r1.CEMI[6];
+          res.resize(1);
+          res[0] = 0;
+          if (obj == 0 && objno == 0)
+            {
+              if (prop == 0)
+                {
+                  res.resize(2);
+                  res[0] = 0;
+                  res[1] = 0;
+                  start = 0;
+                }
+              else
+                count = 0;
+            }
+          else
+            count = 0;
+          CEMI.resize(6 + res.size());
+          CEMI[0] = 0xFB;
+          CEMI[1] = (obj >> 8) & 0xff;
+          CEMI[2] = obj & 0xff;
+          CEMI[3] = objno;
+          CEMI[4] = prop;
+          CEMI[5] = ((count & 0x0f) << 4) | (start >> 8);
+          CEMI[6] = start & 0xff;
+          CEMI.setpart(res, 7);
+
+          auto channel_ptr = this->channel.lock();
+          if (channel_ptr)
+            channel_ptr->sendConfigRequest(CEMI);
+
+          return E_NO_ERROR;
+        }
+      else
+        return E_DATA_CONNECTION;
+    }
+  else
+    return E_DATA_CONNECTION;
+}

--- a/src/libserver/tunchannel.h
+++ b/src/libserver/tunchannel.h
@@ -1,0 +1,151 @@
+/*
+    EIBD eib bus access and management daemon
+    Copyright (C) 2005-2011 Martin Koegler <mkoegler@auto.tuwien.ac.at>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+/**
+ * @file
+ * @ingroup KNX_03_08_01
+ * KNXnet/IP
+ * @{
+ */
+
+#ifndef TUNCHANNEL_H
+#define TUNCHANNEL_H
+
+#include "eibnetip.h"
+#include "link.h"
+#include "router.h"
+
+class TunChannel;
+using TunChannelPtr = std::shared_ptr<TunChannel>;
+
+class TunService;
+using TunServicePtr = std::shared_ptr<TunService>;
+
+class TcpTunConn;
+using TcpTunConnPtr = std::shared_ptr<TcpTunConn>;
+
+class TunChannel
+{
+public:
+  TunChannel(const TcpTunConnPtr& connection, uint8_t channelID);
+  virtual ~TunChannel();
+
+  void setService(const TunServicePtr& service);
+
+  bool setupChannel();
+  void start();
+  void stop(bool err);
+
+  void sendTunnelRequest(const CArray& cemi);
+  void sendConfigRequest(const CArray& cemi);
+
+  // handle various packets from the connection
+  void receiveTunnelRequest(EIBnet_TunnelRequest &r1);
+  void receiveConfigRequest(EIBnet_ConfigRequest &r1);
+
+  TracePtr t;
+  std::weak_ptr<TcpTunConn> connection;
+  TunServicePtr service;
+  uint8_t channelID;
+
+  // Sending sequence counter
+  uint8_t sno = 0;
+  // Receiving sequence counter
+  uint8_t rno = 0;
+};
+
+class TunService
+{
+public:
+  TunService(const std::shared_ptr<TunChannel>& channel);
+  virtual ~TunService();
+
+  virtual bool setupService() = 0;
+  virtual void start() = 0;
+  virtual void stop(bool err) = 0;
+
+  virtual ErrorCode handleTunnelRequest(EIBnet_TunnelRequest& r1);
+  virtual ErrorCode handleConfigRequest(EIBnet_ConfigRequest &r1);
+
+  TracePtr t;
+  std::weak_ptr<TunChannel> channel;
+};
+
+class TunServiceLinkLayer : public SubDriver, public TunService
+{
+public:
+  using TunService::t;
+
+  TunServiceLinkLayer(const std::shared_ptr<TunChannel>& channel, Router& router, LinkConnectClientPtr c);
+  virtual ~TunServiceLinkLayer();
+
+  ErrorCode handleTunnelRequest(EIBnet_TunnelRequest& r1) override;
+
+  bool setupService() override;
+  void start() override;
+  void stop(bool err) override;
+
+  bool setup() override;
+
+  void send_L_Data(LDataPtr l) override;
+
+  bool allocAddress();
+  void freeAddress();
+
+  bool hasAddress(eibaddr_t a) const override
+  {
+    return knxaddr && knxaddr == a;
+  }
+
+  Router& router;
+  eibaddr_t knxaddr = 0;
+};
+
+class TunServiceBusMonitor : public TunService, public L_Busmonitor_CallBack
+{
+public:
+  TunServiceBusMonitor(const std::shared_ptr<TunChannel>& channel, Router& router);
+  virtual ~TunServiceBusMonitor();
+
+  bool setupService() override;
+  void start() override;
+  void stop(bool err) override;
+
+  void send_L_Busmonitor(LBusmonPtr l) override;
+
+  Router& router;
+  int no = 1;
+};
+
+class TunServiceConfig : public TunService
+{
+public:
+  TunServiceConfig(const std::shared_ptr<TunChannel>& channel);
+  virtual ~TunServiceConfig();
+
+  bool setupService() override;
+  void start() override;
+  void stop(bool err) override;
+
+  ErrorCode handleConfigRequest(EIBnet_ConfigRequest &r1) override;
+};
+
+#endif
+
+/** @} */

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,5 +1,5 @@
 if HAVE_SYSTEMD
-systemdsystemunit_DATA=knxd.service knxd.socket
+systemdsystemunit_DATA=knxd.service knxd.socket knxnetip.socket
 sysconf_DATA=knxd.conf
 systemdsysusers_DATA=sysusers.d/knxd.conf
 all: knxd.service.exp

--- a/systemd/knxd.conf
+++ b/systemd/knxd.conf
@@ -11,8 +11,10 @@ KNXD_OPTS="-e 0.0.1 -E 0.0.2:8 -u /tmp/eib -b ip:"
 #  multicast client (-b ip:).
 # knxd's own bus address is 0.0.1; it will assign 0.0.2…0.0.9 to clients.
 # The knxd.socket file also tells knxd to listen to
-#  /run/eib (socket activation via systemd)
+#  /run/knx (socket activation via systemd)
 #  TCP port 6720 (socket activation via systemd)
+# The knxnetip.socket file also tells knxd to listen for KNXnet/ip connection on
+#  /run/knxnetip (socket activation via systemd)
 # You *need* the -e option. Clients cannot connect without "-E".
 
 # You can read knxd's logs with 

--- a/systemd/knxd.service.in
+++ b/systemd/knxd.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=KNX Daemon
-After=network.target knxd.socket
-Requires=knxd.socket
+After=network.target knxd.socket knxnetip.socket
+Requires=knxd.socket knxnetip.socket
 
 [Service]
 EnvironmentFile=@sysconfdir@/knxd.conf
@@ -15,4 +15,4 @@ RestartSec=10
 
 [Install]
 WantedBy=multi-user.target network-online.target
-Also=knxd.socket
+Also=knxd.socket knxnetip.socket

--- a/systemd/knxnetip.socket.in
+++ b/systemd/knxnetip.socket.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=KNXnet/IP socket
+
+[Socket]
+FileDescriptorName=knxnetip
+ListenStream=@RUNDIR@/knxnetip
+SocketGroup=knxd
+SocketMode=0660
+Service=knxd.service
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Implement a TCP tunnelling server according to ISO 22510:2019.

In addition to TCP, the server can also listen on a Unix domain socket, where the same protocol as for TCP will be used. A Unix domain socket will allow using the permissions of the socket to limit who can access the KNX bus (only when using the systemd integration).

This commit was tested with xknx as a client.
