### PR TITLE
Reinstate '--yes' for unprompted install/removal

### DIFF
--- a/install-debian.sh
+++ b/install-debian.sh
@@ -6,7 +6,7 @@ export LC_ALL=C.UTF-8
 cd "$(dirname "$0")"
 
 : 1 install tools, minimal variant
-sudo apt-get install --no-install-recommends build-essential devscripts equivs
+sudo apt-get install --no-install-recommends build-essential devscripts equivs --yes
 
 : 2 auto-install packages required for building knxd
 sudo mk-build-deps --install --tool='apt-get --no-install-recommends --yes --allow-unauthenticated' debian/control
@@ -21,5 +21,5 @@ cd ..
 sudo dpkg -i knxd_*.deb knxd-tools_*.deb
 
 : 5 Clean up. Optional. Remove this if you want to rebuild soon-ish.
-sudo apt remove --autoremove knxd-build-deps
+sudo apt remove --autoremove knxd-build-deps --yes
 


### PR DESCRIPTION
Hey Matthias,

Quite by coincidence I did a new build this morning and was prompted with `Do you want to continue? [Y/n]`.

I see the --yes dropped out of two steps in your update yesterday. (Ref #582 )

;-)

\- Greig.