### PR TITLE
Fix deprecation warning in findknxusb regarding `libusb_set_debug`

### DIFF
--- a/src/usb/findknxusb.cpp
+++ b/src/usb/findknxusb.cpp
@@ -123,7 +123,6 @@ main ()
       fprintf (stderr, "libusb init failure\n");
       exit (1);
     }
-  libusb_set_debug (context, 0);
   printf ("Possible addresses for KNX USB devices:\n");
   count = libusb_get_device_list (context, &devs);
 


### PR DESCRIPTION
The default value is `LIBUSB_LOG_LEVEL_NONE` (0) anyway, so there is no point in setting that value right after initialization.

https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html