### PR TITLE
Fixes for serial drivers: Port config keys + TP-UART via TCP comes up again

### DIFF
--- a/src/backend/ft12.cpp
+++ b/src/backend/ft12.cpp
@@ -115,7 +115,7 @@ FT12wrap::setup()
   if (cfg->value("device","").length() > 0)
     {
       if (cfg->value("ip-address","").length() > 0 ||
-          cfg->value("port",-1) != -1)
+          cfg->value("dest-port",-1) != -1)
         {
           ERRORPRINTF (t, E_ERROR | 5, "Don't specify both device and IP options!");
           return false;

--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -369,7 +369,8 @@ TPUARTwrap::enableInputParityCheck()
 
   if (fd_driver == nullptr)
   {
-    return -3;
+    // Not possible and not necessary to enable on TCP connections, so just continue.
+    return 0;
   }
 
   TRACEPRINTF (t, 8, "Enabling input parity check on fd %d\n", fd_driver->get_fd());

--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -131,7 +131,7 @@ TPUARTwrap::setup()
   if (cfg->value("device","").length() > 0)
     {
       if (cfg->value("ip-address","").length() > 0 ||
-          cfg->value("port",-1) != -1)
+          cfg->value("dest-port",-1) != -1)
         {
           ERRORPRINTF (t, E_ERROR | 25, "Don't specify both device and IP options!");
           return false;


### PR DESCRIPTION
`LLtcp` reads config key `dest-port`, but both `FT12wrap` and `TPUARTwrap` checked for existence of the `port` key in config validation code. Unify that.

TP-UART via TCP cannot enable parity checking as that is neither possible nor necessary on TCP connections. Failing the operation means that the whole interface resets the TP-UART chip three times, then marks the interface down. Instead, the operation should succeed (it's a no-op). This effectively reverts the behavior for TP-UART *via TCP* to the status pre-#534, i.e. it fixes a regression introduced in version 0.14.57. Closes #591. Closes #583.