### PR TITLE
Fix pace filter error message and documentation

### DIFF
--- a/doc/inifile.rst
+++ b/doc/inifile.rst
@@ -1105,7 +1105,7 @@ Limit the rate at which packets are transmitted to an interface.
 
   The delay between transmissions.
   
-  Optional. The default is 20 msec.
+  Optional. The default is 15 msec.
 
 * delay-per-byte (float, msec)
 

--- a/src/backend/fpace.cpp
+++ b/src/backend/fpace.cpp
@@ -53,7 +53,7 @@ PaceFilter::setup()
   byte_delay = cfg->value("delay-per-byte",1)/1000.;
   if (byte_delay < 0)
     {
-      ERRORPRINTF(t, E_ERROR | 1, "The delay must be >0");
+      ERRORPRINTF(t, E_ERROR | 1, "The byte delay must be >=0");
       return false;
     }
   factor_in = cfg->value("incoming",0.75);


### PR DESCRIPTION
The default value was changed from 20 to 15 msec in commit 2f157d6dea7a433ca21998beb0615ce4d8124cf2 (version 0.14.3). Update the documentation accordingly.

Also fix error message when the user sets `delay-per-byte` to any value less than zero.