### PR TITLE
Support enabling hardening flags

### DIFF
--- a/src/client/go/Makefile.am
+++ b/src/client/go/Makefile.am
@@ -1,11 +1,10 @@
 CC = $(CC_FOR_BUILD)
-CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
-CFLAGS = $(CFLAGS_FOR_BUILD)
-LDFLAGS = $(LDFLAGS_FOR_BUILD)
 LIBS = $(LIBS_FOR_BUILD)
 EXEEXT = $(EXEEXT_FOR_BUILD)
 
-AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client
+AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client $(CPPFLAGS_FOR_BUILD)
+AM_CFLAGS = $(CFLAGS_FOR_BUILD)
+AM_LDFLAGS = $(LDFLAGS_FOR_BUILD)
 
 EXTRA_DIST = io.inc
 CLEANFILES = gen.inc EIBConnection.go result.inc

--- a/src/client/lua/Makefile.am
+++ b/src/client/lua/Makefile.am
@@ -1,11 +1,10 @@
 CC = $(CC_FOR_BUILD)
-CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
-CFLAGS = $(CFLAGS_FOR_BUILD)
-LDFLAGS = $(LDFLAGS_FOR_BUILD)
 LIBS = $(LIBS_FOR_BUILD)
 EXEEXT = $(EXEEXT_FOR_BUILD)
 
-AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client
+AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client $(CPPFLAGS_FOR_BUILD)
+AM_CFLAGS = $(CFLAGS_FOR_BUILD)
+AM_LDFLAGS = $(LDFLAGS_FOR_BUILD)
 
 EXTRA_DIST = io.inc
 CLEANFILES = gen.inc EIBConnection.lua result.inc

--- a/src/client/pascal/Makefile.am
+++ b/src/client/pascal/Makefile.am
@@ -1,11 +1,10 @@
 CC = $(CC_FOR_BUILD)
-CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
-CFLAGS = $(CFLAGS_FOR_BUILD)
-LDFLAGS = $(LDFLAGS_FOR_BUILD)
 LIBS = $(LIBS_FOR_BUILD)
 EXEEXT = $(EXEEXT_FOR_BUILD)
 
-AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client
+AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client $(CPPFLAGS_FOR_BUILD)
+AM_CFLAGS = $(CFLAGS_FOR_BUILD)
+AM_LDFLAGS = $(LDFLAGS_FOR_BUILD)
 
 EXTRA_DIST = header1.inc header2.inc body1.inc body2.inc hdef.def
 CLEANFILES = genh.inc gen.inc result.inc EIBD.pas

--- a/src/client/python/Makefile.am
+++ b/src/client/python/Makefile.am
@@ -1,11 +1,10 @@
 CC = $(CC_FOR_BUILD)
-CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
-CFLAGS = $(CFLAGS_FOR_BUILD)
-LDFLAGS = $(LDFLAGS_FOR_BUILD)
 LIBS = $(LIBS_FOR_BUILD)
 EXEEXT = $(EXEEXT_FOR_BUILD)
 
-AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client
+AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client $(CPPFLAGS_FOR_BUILD)
+AM_CFLAGS = $(CFLAGS_FOR_BUILD)
+AM_LDFLAGS = $(LDFLAGS_FOR_BUILD)
 
 EXTRA_DIST = io.inc
 CLEANFILES = gen.inc EIBConnection.py result.inc

--- a/src/client/ruby/Makefile.am
+++ b/src/client/ruby/Makefile.am
@@ -1,11 +1,10 @@
 CC = $(CC_FOR_BUILD)
-CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
-CFLAGS = $(CFLAGS_FOR_BUILD)
-LDFLAGS = $(LDFLAGS_FOR_BUILD)
 LIBS = $(LIBS_FOR_BUILD)
 EXEEXT = $(EXEEXT_FOR_BUILD)
 
-AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client
+AM_CPPFLAGS=-I$(top_srcdir)/src/include -I$(top_srcdir)/src/client -I$(top_builddir)/src/client $(CPPFLAGS_FOR_BUILD)
+AM_CFLAGS = $(CFLAGS_FOR_BUILD)
+AM_LDFLAGS = $(LDFLAGS_FOR_BUILD)
 
 EXTRA_DIST=io.inc footer.inc result.inc
 CLEANFILES = gen.inc EIBConnection.rb result.inc

--- a/src/libserver/tcptunserver.cpp
+++ b/src/libserver/tcptunserver.cpp
@@ -49,16 +49,16 @@ TcpTunConn::TcpTunConn(TcpTunServerBase *parent, uint32_t connectionID, int fd)
       localSocketAddress.sin_family != AF_INET)
     {
       char str[64];
-      snprintf(str, sizeof(str), "stream-%d", connectionID);
+      snprintf(str, sizeof(str), "stream-%u", connectionID);
       t->setAuxName(str);
     }
   else
     {
-      char addrStr[64];
+      char addrStr[INET_ADDRSTRLEN];
       if (inet_ntop(localSocketAddress.sin_family, &localSocketAddress.sin_addr, addrStr, sizeof(addrStr)))
         {
-          char addrPortStr[64];
-          snprintf(addrPortStr, sizeof(addrPortStr), "%s:%d", addrStr, localSocketAddress.sin_port);
+          char addrPortStr[INET_ADDRSTRLEN + 6];
+          snprintf(addrPortStr, sizeof(addrPortStr), "%s:%hu", addrStr, localSocketAddress.sin_port);
           t->setAuxName(addrPortStr);
         }
       else

--- a/src/tools/knxtool.c
+++ b/src/tools/knxtool.c
@@ -379,7 +379,7 @@ vbusmonitor1time\n");
               char logfile[32];
               FILE *new_fd;
               prev_day = loctim->tm_yday;
-              snprintf (logfile, 31, "knx-%d-%d-%d.log",
+              snprintf (logfile, 31, "knx-%hd-%02hd-%02hd.log",
                         loctim->tm_year + 1900,
                         loctim->tm_mon + 1, loctim->tm_mday);
 
@@ -398,7 +398,7 @@ vbusmonitor1time\n");
                   fprintf (log_fd, "Logfile opened\n");
                 }
             }
-          fprintf (log_fd, "%d-%02d-%02d %d:%d:%d : %s\n",
+          fprintf (log_fd, "%d-%02d-%02d %02d:%02d:%02d : %s\n",
                    loctim->tm_year + 1900,
                    loctim->tm_mon + 1,
                    loctim->tm_mday,


### PR DESCRIPTION
Update a format string in knxtool to support building with `-Wformat-truncation=`, which is e.g. enabled in Debian when using `hardening=+all`.

Instead of overwriting `CFLAGS`, `CPPFLAGS`, and `LDFLAGS` when building the client libraries, ensure to keep the values around and merely add to them. This ensures common flags to be used for all compilations, including for all client libraries.