### PR TITLE
Add knxnet.socket to Debian build

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -11,6 +11,7 @@
 /knxd.install
 /knxd.service
 /knxd.socket
+/knxnet.socket
 /autoreconf.after
 /autoreconf.before
 /debhelper-build-stamp

--- a/debian/knxd.install.systemd
+++ b/debian/knxd.install.systemd
@@ -1,2 +1,3 @@
 etc/knxd.conf
+lib/systemd/system/knxnet.socket
 usr/lib/sysusers.d

--- a/debian/rules
+++ b/debian/rules
@@ -23,7 +23,7 @@ override_dh_auto_configure: configure install-sh
 configure install-sh: configure.ac
 	sh bootstrap.sh
 
-override_dh_install: debian/knxd.install debian/knxd.socket debian/knxd.service debian/knxd.udev
+override_dh_install: debian/knxd.install debian/knxd.socket debian/knxnet.socket debian/knxd.service debian/knxd.udev
 	dh_install
 	dh_systemd_enable || true
 	dh_systemd_start || true
@@ -40,9 +40,11 @@ debian/knxd.udev: systemd/knxd.udev
 
 debian/knxd.socket: systemd/knxd.socket
 	test -e $^ && cp $^ $@
+debian/knxnet.socket: systemd/knxnet.socket
+	test -e $^ && cp $^ $@
 debian/knxd.service: systemd/knxd.service
 	test -e $^ && cp $^ $@
-systemd/knxd.socket systemd/knxd.service:
+systemd/knxd.socket systemd/knxnet.socket systemd/knxd.service:
 	$(MAKE) -C systemd
 
 override_dh_auto_test:


### PR DESCRIPTION
Tripped over this several days ago, and @FrankEisi also mentioned it in #578: After merging the TCP Tunneling support and adding `knxnet.socket`, the Debian packaging was not updated accordingly. Make up for this now.