### PR TITLE
Fix dereference of empty std::vector data() pointer

### DIFF
--- a/src/backend/tpuart.cpp
+++ b/src/backend/tpuart.cpp
@@ -548,7 +548,7 @@ TPUARTwrap::recv_Data(CArray &c)
         */
       else if (c == 0xCC || c == 0xC0 || c == 0x0C)
         {
-          RecvLPDU (in.data(), 1);
+          RecvLPDU (&c, 1);
         }
       else if ((c & 0x50) == 0x10) // Matches KNX control byte L_Data_Standard/Extended Frame
         {


### PR DESCRIPTION
Closes #597 

See note on `std::vector<T,Allocator>::data` [1]:

> If size() is ​0​, data() may or may not return a null pointer.

[1] https://en.cppreference.com/w/cpp/container/vector/data