### PR TITLE
Introduce GitHub Actions and fix build warnings and breaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: CI
+
+on:
+  push:
+    branches: "*"
+  pull_request:
+    branches: "*"
+
+permissions: {}
+
+jobs:
+  # On Ubuntu, because that is the standard OS of GitHub Actions.
+  build_ubuntu:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get dist-upgrade -y
+        sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev libsystemd-dev libev-dev libfmt-dev libinih-dev
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Full history to be able to determine version number
+
+    - name: Bootstrap
+      run: sh bootstrap.sh
+
+    - name: Configure
+      run: ./configure
+
+    - name: Build
+      run: make -j$(nproc)
+
+    - name: Test
+      run: make -j1 test
+
+    - name: Install
+      run: sudo make -j1 install
+
+  # On Alpine, because it's a tiny distro heavily used in containers.
+  build_alpine:
+
+    runs-on: ubuntu-latest
+    container: alpine
+
+    steps:
+    - name: Install build dependencies
+      run: |
+        apk update
+        apk upgrade
+        apk add git build-base autoconf automake libtool argp-standalone linux-headers libusb-dev libev-dev fmt-dev inih-dev
+
+    - name: Configure git in container
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Full history to be able to determine version number
+
+    - name: Bootstrap
+      run: sh bootstrap.sh
+
+    - name: Configure
+      run: ./configure --disable-systemd
+
+    - name: Build
+      run: make -j$(nproc)
+
+    - name: Test
+      run: make -j1 test
+
+    - name: Install
+      run: make -j1 install
+
+  # Debian packaging; May break when code changes require updates to the Debian package.
+  # Merges the pushed/proposed code changes to the `debian` branch and builds that then.
+  package_debian:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [testing, stable, oldstable]
+    runs-on: ubuntu-latest
+    container: debian:${{ matrix.suite }}-slim
+
+    steps:
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get dist-upgrade -y
+        apt-get install -y --no-install-recommends ca-certificates git sudo
+
+    - name: Configure git in container
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git config --global user.name "Your Name"
+        git config --global user.email "you@example.com"
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Full history to be able to determine version number
+
+    - name: Merge into debian branch
+      run: git checkout debian && git merge "$GITHUB_REF"
+
+    - name: Build and install
+      run: sh install-debian.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,4 +37,3 @@ config.h: configure
 
 test: all
 	sh tools/test.sh
-	tools/test_inih tools/test.ini tools/bad*.ini

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ This part covers "manual" installation.
     sh bootstrap.sh
     ./configure --help
     ./configure --your-chosen-options
-    make
+    make -j$(nproc)
     make install
     cd ..
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-knxd [![Build Status](https://travis-ci.org/knxd/knxd.svg)](https://travis-ci.org/knxd/knxd)
+knxd [![CI](https://github.com/knxd/knxd/actions/workflows/ci.yml/badge.svg)](https://github.com/knxd/knxd/actions/workflows/ci.yml)
 ====
 
 KNX is a very common building automation protocol which runs on dedicated 9600-baud wire as well as IP multicast.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ esac
 
 # on Debian systems we need pkg-config
 if which dpkg >/dev/null && ! which pkg-config >/dev/null ; then
-	echo "Package 'pkg-config' missing."
+	echo "Tool 'pkg-config' missing. Install package 'pkgconf' or older 'pkg-config'."
 	exit 2
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,10 +23,10 @@ dnl ##    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 dnl ##    SUCH DAMAGE.
 
 
-AC_PREREQ([2.72])
+AC_PREREQ([2.69])
 LT_PREREQ([2.2.0])
 
-AC_INIT([knxd],m4_esyscmd(sh -c "./tools/version.sh | tr -d '\n'"))
+AC_INIT([knxd],m4_esyscmd_s([./tools/version.sh]))
 AC_CONFIG_SRCDIR([src/server/knxd.cpp])
 AM_INIT_AUTOMAKE
 LT_INIT

--- a/src/usb/usb.cpp
+++ b/src/usb/usb.cpp
@@ -19,7 +19,7 @@
 
 #include <cstdlib>
 #include <cerrno>
-#include <sys/poll.h>
+#include <poll.h>
 #include "usb.h"
 #include "types.h"
 

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -7,7 +7,7 @@ export LD_LIBRARY_PATH=src/client/c/.libs${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
 set -ex
 export PATH="$(pwd)/src/tools/.libs:$(pwd)/src/tools:$(pwd)/src/server/.libs:$(pwd)/src/server:$(pwd)/src/server:$PATH"
 
-EF=$(tempfile)
+EF=$(mktemp)
 
 # first test argument handling
 if knxd -e 1.2.3 --stop-right-now >$EF 2>&1; then
@@ -52,19 +52,19 @@ if ! knxd -e 1.2.3 --stop-right-now -c -b dummy: -b dummy: >$EF 2>&1; then
   exit 0
 fi
 
-S1=$(tempfile); rm $S1
-S2=$(tempfile); rm $S2
-S3=$(tempfile); rm $S3
-L1=$(tempfile)
-L2=$(tempfile)
-L3=$(tempfile)
-L4=$(tempfile)
-L5=$(tempfile)
-E1=$(tempfile)
-E2=$(tempfile)
-E3=$(tempfile)
-E4=$(tempfile)
-E5=$(tempfile)
+S1=$(mktemp); rm $S1
+S2=$(mktemp); rm $S2
+S3=$(mktemp); rm $S3
+L1=$(mktemp)
+L2=$(mktemp)
+L3=$(mktemp)
+L4=$(mktemp)
+L5=$(mktemp)
+E1=$(mktemp)
+E2=$(mktemp)
+E3=$(mktemp)
+E4=$(mktemp)
+E5=$(mktemp)
 
 PORT=$((9999 + $$))
 PORT2=$((9998 + $$))

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -2,7 +2,7 @@
 
 # Sorry about the Debian nonsense in here but the build system doesn't
 # patch the file early enough and overriding it is a PITA
-if test -s debian/changelog ; then
+if test -s debian/changelog && which dpkg-parsechangelog >/dev/null ; then
     dpkg-parsechangelog -SVersion | sed -e 's/.*://' -e 's/-.*//'
     exit
 fi


### PR DESCRIPTION
@smurfix Please enable GitHub Actions in knxd if it is not enabled yet before merging this PR.

The ci.yml file builds knxd on every push and every created PR on:
* Ubuntu with the Linux build approach
* Alpine
* Debian testing + stable + oldstable, by merging the proposed changes into the debian branch and building the Debian package from there on the respective suite. This step can obviously fail e.g. due to merge conflicts. Still, I think it's better to know upfront when something needs additional action when merging into `debian` than it is to find out later, and this verifies compatibility of every change with the listed suites.

To note:
* Closes #609 as it dials back autoconf requirement to 2.69 for compatibility with Debian oldstable (currently Bullseye)
* Closes #574 as it clearly shows that compilation works on Bookworm