### PR TITLE
Fix FT 1.2 segmentation fault and make FT 1.2 and NCN5120 compatible with more USB-to-serial adapters

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
 Stefan Hoffmeister <stefan@hoffmeister.biz>
-Michael Markstaller <mm@elabnet.de>
+Michael Markstaller <michael@markstaller.de> <mm@elabnet.de>
 Joerg Mattiello <dev@mjoe.org> <jmattiello@gmail.com>
 Patrik Pfaffenbauer <patrik.pfaffenbauer@p3.co.at> <dev@tera-dev.beka-consulting.local>
 Timo Wingender <github@timo-wingender.de>

--- a/AUTHORS
+++ b/AUTHORS
@@ -39,7 +39,6 @@ Harald Leithner <leithner@itronic.at>
 Tobias Lorenz <tobias.lorenz@gmx.net>
 MagicBear <magicbearmo@gmail.com>
 Michael Markstaller <michael@markstaller.de>
-Michael Markstaller <mm@elabnet.de>
 Joerg Mattiello <dev@mjoe.org>
 Race666 <michael@albert-hetzles.de>
 Sebastian <Morg42@users.noreply.github.com>

--- a/src/backend/ft12.cpp
+++ b/src/backend/ft12.cpp
@@ -44,7 +44,7 @@ protected:
   void termios_settings (struct termios &t1)
   {
     t1.c_cflag = CS8 | CLOCAL | CREAD | PARENB;
-    t1.c_iflag = IGNBRK | INPCK | ISIG;
+    t1.c_iflag = IGNBRK | ISIG;
     t1.c_oflag = 0;
     t1.c_lflag = 0;
     t1.c_cc[VTIME] = 1;
@@ -120,7 +120,8 @@ FT12wrap::setup()
           ERRORPRINTF (t, E_ERROR | 5, "Don't specify both device and IP options!");
           return false;
         }
-      iface = new FT12serial(this, cfg);
+      ll_serial = new FT12serial(this, cfg);
+      iface = ll_serial;
     }
   else
     {
@@ -325,6 +326,10 @@ FT12wrap::process_read(bool is_timeout)
                   const uint8_t reset[1] = { 0xA0 };
                   CArray c = CArray (reset, sizeof (reset));
                   t->TracePacket (0, "RecvReset", c);
+                  if (ll_serial != nullptr)
+                    {
+                      ll_serial->enable_input_parity_check();
+                    }
                   LowLevelFilter::recv_Data (c);
                 }
               akt.deletepart (0, 4);
@@ -444,5 +449,3 @@ FT12CEMIDriver::cmdOpen()
   const uint8_t t1[] = { 0xF6, 0x00, 0x08, 0x01, 0x34, 0x10, 0x01, 0x00 };
   send_Local (CArray (t1, sizeof (t1)),1);
 }
-
-

--- a/src/backend/ft12.h
+++ b/src/backend/ft12.h
@@ -24,6 +24,7 @@
 
 #include "iobuf.h"
 #include "lowlevel.h"
+#include "llserial.h"
 #include "emi_common.h"
 #include "lowlatency.h"
 #include "link.h"
@@ -125,6 +126,9 @@ public:
   void do_send_Local (CArray& l, int raw = 0);
 
   void sendReset();
+
+private:
+  LLserial *ll_serial = nullptr;
 };
 
 #endif

--- a/src/backend/ncn5120.cpp
+++ b/src/backend/ncn5120.cpp
@@ -34,7 +34,7 @@ protected:
   void setstate(enum TSTATE state);
 
   void RecvLPDU (const uint8_t * data, int len);
-  virtual FDdriver * create_serial(LowLevelIface* parent, IniSectionPtr& s);
+  virtual LLserial * create_serial(LowLevelIface* parent, IniSectionPtr& s);
 };
 
 class NCN5120serial : public LLserial
@@ -54,7 +54,7 @@ protected:
   void termios_settings(struct termios &t1)
   {
     t1.c_cflag = CS8 | CLOCAL | CREAD;
-    t1.c_iflag = IGNBRK | INPCK | ISIG;
+    t1.c_iflag = IGNBRK | ISIG;
     t1.c_oflag = 0;
     t1.c_lflag = 0;
     t1.c_cc[VTIME] = 1;
@@ -69,11 +69,10 @@ NCN5120::create_wrapper(LowLevelIface* parent, IniSectionPtr& s, LowLevelDriver*
 }
 
 
-FDdriver *
+LLserial *
 NCN5120wrap::create_serial(LowLevelIface* parent, IniSectionPtr& s)
 {
-  fd_driver = new NCN5120serial(parent,s);
-  return fd_driver;
+  return new NCN5120serial(parent, s);
 }
 
 void NCN5120wrap::RecvLPDU (const uint8_t * data, int len)
@@ -94,4 +93,3 @@ NCN5120wrap::setstate(enum TSTATE new_state)
     }
   TPUARTwrap::setstate(new_state);
 }
-

--- a/src/backend/tpuart.h
+++ b/src/backend/tpuart.h
@@ -24,6 +24,7 @@
 #include "link.h"
 #include "lpdu.h"
 #include "lowlevel.h"
+#include "llserial.h"
 
 // also update SN() in tpuart.cpp
 enum TSTATE
@@ -107,11 +108,11 @@ public:
   void send_L_Data (LDataPtr l);
 
 protected:
-  virtual FDdriver * create_serial(LowLevelIface* parent, IniSectionPtr& s);
-  FDdriver *fd_driver = NULL;
+  virtual LLserial * create_serial(LowLevelIface* parent, IniSectionPtr& s);
 
 private:
-  int enableInputParityCheck();
+  LLserial *ll_serial = nullptr;
+  int enable_input_parity_check();
 };
 
 #endif

--- a/src/libserver/emi2.cpp
+++ b/src/libserver/emi2.cpp
@@ -25,6 +25,7 @@ EMI2Driver::EMI2Driver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i) :
 {
   t->setAuxName("EMI2");
   sendLocal_done.set<EMI2Driver,&EMI2Driver::sendLocal_done_cb>(this);
+  reset_timer.set<EMI2Driver,&EMI2Driver::reset_timer_cb>(this);
 }
 
 void

--- a/src/libserver/llserial.cpp
+++ b/src/libserver/llserial.cpp
@@ -149,3 +149,26 @@ LLserial::stop(bool err)
   FDdriver::stop(err);
 }
 
+int
+LLserial::enable_input_parity_check()
+{
+  struct termios t1;
+
+  TRACEPRINTF (t, 8, "Enabling input parity check on fd %d\n", fd);
+
+  if (tcgetattr (fd, &t1))
+  {
+    ERRORPRINTF (t, E_ERROR | 70, "tcgetattr failed: %s", strerror(errno));
+    return -1;
+  }
+
+  t1.c_iflag = t1.c_iflag | INPCK;
+
+  if (tcsetattr (fd, TCSANOW, &t1))
+  {
+    ERRORPRINTF (t, E_ERROR | 70, "tcsetattr failed: %s", strerror(errno));
+    return -2;
+  }
+
+  return 0;
+}

--- a/src/libserver/llserial.h
+++ b/src/libserver/llserial.h
@@ -47,6 +47,7 @@ public:
   bool setup();
   void start();
   void stop(bool err);
+  int enable_input_parity_check();
 
 private:
   low_latency_save sold;

--- a/src/libserver/lowlevel.cpp
+++ b/src/libserver/lowlevel.cpp
@@ -232,8 +232,3 @@ HWBusDriver::setup()
     return false;
   return true;
 }
-
-int FDdriver::get_fd()
-{
-  return fd;
-}

--- a/src/libserver/lowlevel.h
+++ b/src/libserver/lowlevel.h
@@ -281,7 +281,6 @@ public:
   bool setup();
   void start();
   void stop(bool err);
-  int get_fd();
 
 protected:
   /** device connection */


### PR DESCRIPTION
Very sure the missing initialization of `EMI2Driver::reset_timer` added in 75b466b7b0c2c8725edbfcad52f8869e7b17c868 fixes the segmentation fault reported in #485 and #606.

However, that just changes the error from an ugly crash to a somewhat nicer user friendly error message `"reset timed out"`, but does not make the ft12 interface work, so something else must be going on. Remembering that #534 introduced a parity error fix for TP-UART when used with some USB-to-serial adapters and me wondering why it was not applied to the other serial interfaces in an equal manner (namely NCN5120 and FT 1.2), this PR takes a stab and applies the same logic to these serial interfaces as well, in the hope that it makes them work.

Unfortunately, I cannot test these changes as I don't own the necessary hardware.

@gvtienen Can you try this out with your FT 1.2 interface, please?
@smurfix Can you test this with NCN5120 and TP-UART, please?

Closes #485 
Closes #606 

(Also fixing another duplicate AUTHORS entry here.)