### PR TITLE
remove obsolete check for old libraries

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
-if test -f /usr/local/lib/libeibclient.so.0 ; then
-	echo "*** You have old eibd libraries lying around in /usr/local/lib." >&2
-	echo "*** Remove them before building or installing knxd." >&2
-	exit 1
-fi
+
 case `uname` in
 	Darwin*)
 		LIBTOOLIZE=glibtoolize ;;


### PR DESCRIPTION
knxd uses the same library names in the default installation location as the old eibd.
With this check for old libraries in place it's not possible to compile a new knxd version using bootstap.sh on a system with knxd already installed in the default location.
Therefore this check should be removed.