### PR TITLE
Mark RC bug #1091852 as fixed in version 0.14.71-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ knxd (0.14.72-1) unstable; urgency=medium
 knxd (0.14.71-1) unstable; urgency=medium
 
   * Merge
+  * Do not build examples. Closes: #1091852
 
  -- Matthias Urlichs <matthias@urlichs.de>  Tue, 17 Dec 2024 22:22:04 +0100
 


### PR DESCRIPTION
An RC bug has been reported in Debian for the broken build that has been fixed in commit 78d78feda2dc4d5ab25da03759dee211d5553da8:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091852

Mark it as fixed in 0.14.71-1 via the changelog.

**When this is merged, please upload to Debian. At the moment, knxd is missing from Trixie (testing) and it should migrate before the upcoming freeze --> https://release.debian.org/**