### PR TITLE
Fix parsing error causing "Too many arguments for usb!"

### DIFF
--- a/src/server/knxd_args.cpp
+++ b/src/server/knxd_args.cpp
@@ -274,7 +274,7 @@ void driver_args(const char *arg, char *ap)
       driver_argsv(cut,ap, "!ip-address","!dest-port", NULL);
     }
   else if(!strcmp(arg,"usb"))
-    driver_argsv(arg,ap, "bus","device","config","interface", NULL);
+    driver_argsv(arg,ap, "bus","device","config","setting","interface", NULL);
   else if(!strcmp(arg,"ipt"))
     driver_argsv(arg,ap, "!ip-address","dest-port","src-port", NULL);
   else if(!strcmp(arg,"iptn"))


### PR DESCRIPTION
Fixes #285

`knxd_args` bails out with error "Too many arguments for usb!" because only 4 of the 5 parts of numeric USB configuration have been parsed so far. This PR adds the missing one in the correct spot.