### PR TITLE
set rundir to /run

### DIFF
--- a/m4/paths.m4
+++ b/m4/paths.m4
@@ -39,7 +39,7 @@ SHAREDIR=`eval echo $prefix/share`
 AC_SUBST(SHAREDIR)
 
 dnl Not part of a ./configure option, does LSB define it?
-RUNDIR="/var/run"
+RUNDIR="/run"
 AC_SUBST(RUNDIR)
 
 CONFIG_DIR=/etc


### PR DESCRIPTION
set rundir path to /run to follow common environment definitions