### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Run these steps as normal user, not as root.
 
 On Debian/Ubuntu:
 
-    sudo apt-get install git
+    sudo apt-get install git systemd-dev
 
     # get the source code
     git clone -b debian https://github.com/knxd/knxd.git


### PR DESCRIPTION
knxd/debian/rules line 12 refers to variable systemdsystemunitdir which is defined /usr/share/pkgconfig/systemd.pc. So package systemd-dev is required to build knxd correctly on debian. Otherwise the build failed with: dh_install: warning: knxd missing files: /knxd-net.socket
        install -m0755 -d debian/knxd//etc
        cp --reflink=auto -a debian/tmp/etc/knxd.conf debian/knxd//etc/
        install -m0755 -d debian/knxd//usr/bin
        cp --reflink=auto -a debian/tmp/usr/bin/knxd debian/knxd//usr/bin/
        install -m0755 -d debian/knxd//usr/lib
        cp --reflink=auto -a debian/tmp/usr/lib/knxd_args debian/knxd//usr/lib/
dh_install: error: missing files, aborting
make: *** [debian/rules:32: override_dh_install] Error 255 dpkg-buildpackage: error: debian/rules override_dh_install subprocess returned exit status 2

Update: tried this on armbian minimal for a OrangePi PC. build-essential is already installed but systemd-dev is still missing. 