### PR TITLE
Verify and optionally set USB interface individual address

### DIFF
--- a/src/libserver/cemi.cpp
+++ b/src/libserver/cemi.cpp
@@ -35,6 +35,18 @@ CEMIDriver::CEMIDriver (LowLevelIface* c, IniSectionPtr& s, LowLevelDriver *i) :
   t->setAuxName("CEMI");
   sendLocal_done.set<CEMIDriver,&CEMIDriver::sendLocal_done_cb>(this);
   reset_timer.set<CEMIDriver,&CEMIDriver::reset_timer_cb>(this);
+
+  // Read address from config - format: X.Y.Z in "addr" key
+  std::string addrStr = cfg->value("addr", "");
+  if (!addrStr.empty())
+    {
+      int a, b, c;
+      if (sscanf(addrStr.c_str(), "%d.%d.%d", &a, &b, &c) == 3)
+        {
+          config_addr = ((a & 0x0f) << 12) | ((b & 0x0f) << 8) | (c & 0xff);
+          config_addr_set = true;
+        }
+    }
 }
 
 void
@@ -74,7 +86,11 @@ void CEMIDriver::started()
 {
   sent_comm_mode = false;
   after_reset = true;
-  reset_timer.start(0.5,0);
+  init_step = 0;
+  read_subnet = 0;
+  read_device = 0;
+  need_write_addr = false;
+  reset_timer.start(3.0, 0);  // Longer timeout for multi-step init
   sendReset();
 }
 
@@ -88,35 +104,173 @@ void CEMIDriver::do_send_Next()
 {
   if (after_reset)
     {
-      if (!sent_comm_mode)
-        {
-          sent_comm_mode = true;
+      CArray msg;
 
-          // Set the comm mode to "Data Link Layer" (0x00)
-          CArray set_comm_mode;
-          set_comm_mode.resize (8);
-          set_comm_mode[0] = 0xf6; // Message Code (MC), M_PropWrite.req
-          // Interface Object Type = cEMI Server Object
-          set_comm_mode[1] = 0x00; // IOTH
-          set_comm_mode[2] = 0x08; // IOTL
-          set_comm_mode[3] = 0x01; // Object Instance (OI)
-          set_comm_mode[4] = 0x34; // Property ID (PID), PID_COMM_MODE (52)
-          // number of elements (NoE) = 0x1
-          // start index (SIx) = 0x001
-          set_comm_mode[5] = 0x10; // NoE, SIx
-          set_comm_mode[6] = 0x01; // SIx
-          set_comm_mode[7] = 0x00; // Data (0x00 is "Data Link Layer")
-          send_Data (set_comm_mode);
-        }
-      else
+      switch (init_step)
         {
+        case 0:
+          // Step 0: Set comm mode to Data Link Layer
+          init_step = 1;
+          msg.resize(8);
+          msg[0] = 0xf6; // M_PropWrite.req
+          msg[1] = 0x00; // Object Type High (cEMI Server)
+          msg[2] = 0x08; // Object Type Low
+          msg[3] = 0x01; // Object Instance
+          msg[4] = 0x34; // PID_COMM_MODE (52)
+          msg[5] = 0x10; // NoE=1, SIx high
+          msg[6] = 0x01; // SIx low
+          msg[7] = 0x00; // Data Link Layer mode
+          send_Data(msg);
+          break;
+
+        case 1:
+          // Step 1: Read PID_SUBNET_ADDR
+          init_step = 2;
+          msg.resize(7);
+          msg[0] = 0xfc; // M_PropRead.req
+          msg[1] = 0x00; // Object Type High (Device Object)
+          msg[2] = 0x00; // Object Type Low
+          msg[3] = 0x01; // Object Instance
+          msg[4] = 0x39; // PID_SUBNET_ADDR (57)
+          msg[5] = 0x10; // NoE=1, SIx high
+          msg[6] = 0x01; // SIx low
+          send_Data(msg);
+          break;
+
+        case 2:
+          // Step 2: Read PID_DEVICE_ADDR (after receiving subnet response)
+          init_step = 3;
+          msg.resize(7);
+          msg[0] = 0xfc; // M_PropRead.req
+          msg[1] = 0x00; // Object Type High (Device Object)
+          msg[2] = 0x00; // Object Type Low
+          msg[3] = 0x01; // Object Instance
+          msg[4] = 0x3a; // PID_DEVICE_ADDR (58)
+          msg[5] = 0x10; // NoE=1, SIx high
+          msg[6] = 0x01; // SIx low
+          send_Data(msg);
+          break;
+
+        case 3:
+          // Step 3: Evaluate and decide
+          {
+            eibaddr_t usb_addr = ((uint16_t)read_subnet << 8) | read_device;
+            bool is_unconfigured = (usb_addr == 0x0000) || (usb_addr == 0xFFFF);
+
+            if (!config_addr_set)
+              {
+                // No addr configured - warn about individual addressing
+                ERRORPRINTF(t, E_WARNING | 45,
+                  "No addr configured; group communication works but individual addressing may fail");
+                init_step = 6; // Skip to completion
+                do_send_Next();
+              }
+            else if (is_unconfigured)
+              {
+                // USB is unconfigured - program it
+                TRACEPRINTF(t, 1, "USB interface unconfigured, setting address to %d.%d.%d",
+                  (config_addr >> 12) & 0xF, (config_addr >> 8) & 0xF, config_addr & 0xFF);
+                need_write_addr = true;
+                init_step = 4;
+                do_send_Next();
+              }
+            else if (usb_addr == config_addr)
+              {
+                // Addresses match - all good, no log needed
+                init_step = 6; // Skip to completion
+                do_send_Next();
+              }
+            else
+              {
+                // Mismatch - warn but don't overwrite
+                ERRORPRINTF(t, E_WARNING | 46,
+                  "USB interface has address %d.%d.%d but config specifies %d.%d.%d - individual addressing may fail",
+                  (usb_addr >> 12) & 0xF, (usb_addr >> 8) & 0xF, usb_addr & 0xFF,
+                  (config_addr >> 12) & 0xF, (config_addr >> 8) & 0xF, config_addr & 0xFF);
+                init_step = 6; // Skip to completion
+                do_send_Next();
+              }
+          }
+          break;
+
+        case 4:
+          // Step 4: Write PID_SUBNET_ADDR
+          init_step = 5;
+          msg.resize(8);
+          msg[0] = 0xf6; // M_PropWrite.req
+          msg[1] = 0x00; // Object Type High (Device Object)
+          msg[2] = 0x00; // Object Type Low
+          msg[3] = 0x01; // Object Instance
+          msg[4] = 0x39; // PID_SUBNET_ADDR (57)
+          msg[5] = 0x10; // NoE=1, SIx high
+          msg[6] = 0x01; // SIx low
+          msg[7] = (config_addr >> 8) & 0xFF; // Subnet
+          send_Data(msg);
+          break;
+
+        case 5:
+          // Step 5: Write PID_DEVICE_ADDR
+          init_step = 6;
+          msg.resize(8);
+          msg[0] = 0xf6; // M_PropWrite.req
+          msg[1] = 0x00; // Object Type High (Device Object)
+          msg[2] = 0x00; // Object Type Low
+          msg[3] = 0x01; // Object Instance
+          msg[4] = 0x3a; // PID_DEVICE_ADDR (58)
+          msg[5] = 0x10; // NoE=1, SIx high
+          msg[6] = 0x01; // SIx low
+          msg[7] = config_addr & 0xFF; // Device
+          send_Data(msg);
+          break;
+
+        default:
+          // Step 6: Done
           after_reset = false;
           reset_timer.stop();
           EMI_Common::started();
+          break;
         }
     }
   else
     EMI_Common::do_send_Next();
+}
+
+void CEMIDriver::recv_Data(CArray& c)
+{
+  // Intercept M_PropRead.con (0xFB) and M_PropWrite.con (0xF5) during initialization
+  if (after_reset && c.size() >= 7)
+    {
+      uint8_t mc = c[0];
+
+      if (mc == 0xfb && c.size() >= 8) // M_PropRead.con
+        {
+          uint8_t pid = c[4];
+          uint8_t value = c[7];
+
+          if (pid == 0x39) // PID_SUBNET_ADDR
+            {
+              read_subnet = value;
+              TRACEPRINTF(t, 2, "Read USB subnet address: 0x%02X", value);
+            }
+          else if (pid == 0x3a) // PID_DEVICE_ADDR
+            {
+              read_device = value;
+              TRACEPRINTF(t, 2, "Read USB device address: 0x%02X", value);
+            }
+          // Property responses act as confirmations - continue init
+          do_send_Next();
+          return;
+        }
+      else if (mc == 0xf5) // M_PropWrite.con
+        {
+          // Property write confirmed - continue init
+          do_send_Next();
+          return;
+        }
+    }
+
+  // Call parent handler for all other messages
+  EMI_Common::recv_Data(c);
 }
 
 const uint8_t *

--- a/src/libserver/cemi.h
+++ b/src/libserver/cemi.h
@@ -57,9 +57,18 @@ private:
 
   virtual unsigned int maxPacketLen() const override;
   void sendLocal_done_cb(bool success);
+  virtual void recv_Data(CArray& c) override;
 
   bool after_reset = false;
   bool sent_comm_mode = false;
+  int init_step = 0;
+
+  // USB interface address handling
+  eibaddr_t config_addr = 0;      // Address from config
+  bool config_addr_set = false;   // Whether addr was configured
+  uint8_t read_subnet = 0;        // Read subnet value from USB
+  uint8_t read_device = 0;        // Read device value from USB
+  bool need_write_addr = false;   // Whether we need to program USB address
 
   ev::timer reset_timer;
   void reset_timer_cb(ev::timer &w, int revents);


### PR DESCRIPTION
USB KNX interfaces have their own individual address. When knxd sends frames with a source address (e.g., 1.1.100), devices respond to that address. If the USB interface isn't configured with that address, it filters out the responses and knxd never sees them, breaking individual addressing (ETS programming, device management, etc.).

This change adds address verification during cEMI initialization:

1. Read the USB interface's current address (PID_SUBNET_ADDR and PID_DEVICE_ADDR) using M_PropRead.req

2. Compare with the configured 'addr' from knxd.ini:
   - If USB has unconfigured address (0.0.0 or 15.15.255): auto-program from config
   - If addresses match: silent success
   - If addresses differ: log warning but don't overwrite (user may have intentionally configured it differently via ETS)
   - If no addr configured: warn that individual addressing may fail

3. Handle property responses (M_PropRead.con, M_PropWrite.con) during init to properly sequence the multi-step initialization

Closes #646