### PR TITLE
ip: add configurable multicast TTL for KNX/IP routing

### DIFF
--- a/doc/inifile.rst
+++ b/doc/inifile.rst
@@ -429,6 +429,11 @@ the ``ets_router`` server's routing code (no tunnel server, no autodiscovery).
   Optional; the default is the first broadcast-capable interface on your
   system, or the interface which your default route uses.
 
+* multicast-ttl (int; ``-A multicast-ttl=N``)
+
+  IP multicast TTL. Increase this (e.g. to 16) if multicast packets
+  need to traverse IP routers. The default is unset (system default, typically 1).
+
 .. Note::
 
     You **must** use a multicast address here. Direct links to Ip

--- a/src/backend/eibnetrouter.cpp
+++ b/src/backend/eibnetrouter.cpp
@@ -53,6 +53,8 @@ EIBNetIPRouter::start()
       ERRORPRINTF (t, E_ERROR | 58, "interface %s not recognized", interface);
       goto err_out;
     }
+  if (multicast_ttl != 0)
+    sock->SetMulticastTTL(multicast_ttl);
 
   sock->recvall = 2;
   if (GetHostIP (t, &sock->sendaddr, multicastaddr) == 0)
@@ -111,6 +113,7 @@ EIBNetIPRouter::setup()
   port = cfg->value("port",3671);
   interface = cfg->value("interface","");
   monitor = cfg->value("monitor",false);
+  multicast_ttl = cfg->value("multicast-ttl", 0);
   return true;
 }
 

--- a/src/backend/eibnetrouter.h
+++ b/src/backend/eibnetrouter.h
@@ -33,6 +33,7 @@ DRIVER(EIBNetIPRouter,ip)
   std::string multicastaddr;
   uint16_t port;
   bool monitor;
+  int multicast_ttl = 0;
 
   void read_cb(EIBNetIPPacket *p);
   void stop_();

--- a/src/libserver/eibnetip.cpp
+++ b/src/libserver/eibnetip.cpp
@@ -212,6 +212,18 @@ EIBNetIPSocket::SetMulticast (struct ip_mreqn multicastaddr)
   return true;
 }
 
+bool
+EIBNetIPSocket::SetMulticastTTL (int ttl)
+{
+  if (setsockopt (fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof (ttl)) < 0)
+    {
+      ERRORPRINTF (t, E_ERROR | 54, "cannot set multicast TTL to %d: %s", ttl, strerror(errno));
+      return false;
+    }
+  TRACEPRINTF (t, 0, "Multicast TTL set to %d", ttl);
+  return true;
+}
+
 void
 EIBNetIPSocket::Send (EIBNetIPPacket p, struct sockaddr_in addr)
 {

--- a/src/libserver/eibnetip.h
+++ b/src/libserver/eibnetip.h
@@ -473,6 +473,8 @@ public:
 
   /** enables multicast */
   bool SetMulticast (struct ip_mreqn multicastaddr);
+  /** set multicast TTL (default: 1) */
+  bool SetMulticastTTL (int ttl);
   /** sends a packet */
   void Send (EIBNetIPPacket p, struct sockaddr_in addr);
   void Send (EIBNetIPPacket p)


### PR DESCRIPTION
Add a 'multicast-ttl' option to the ip driver (EIBNetIPRouter) to allow overriding the default IP_MULTICAST_TTL value.

The default remains TTL=1 (link-local), preserving existing behavior. No changes are made unless the option is explicitly set.

Closes: #452