### PR TITLE
groupfilter: add group address filter

### DIFF
--- a/src/libserver/Makefile.am
+++ b/src/libserver/Makefile.am
@@ -59,4 +59,4 @@ else
 USB =
 endif
 
-libserver_a_SOURCES = server.h server.cpp localserver.h localserver.cpp inetserver.h inetserver.cpp $(SYSTEMD_SERVER) $(EIBNETIP) $(EMI) $(USB) llserial.h llserial.cpp lltcp.h lltcp.cpp lowlatency.h lowlatency.cpp retry.h retry.cpp
+libserver_a_SOURCES = server.h server.cpp localserver.h localserver.cpp inetserver.h inetserver.cpp $(SYSTEMD_SERVER) $(EIBNETIP) $(EMI) $(USB) llserial.h llserial.cpp lltcp.h lltcp.cpp lowlatency.h lowlatency.cpp retry.h retry.cpp groupfilter.h groupfilter.cpp

--- a/src/libserver/groupfilter.cpp
+++ b/src/libserver/groupfilter.cpp
@@ -1,0 +1,136 @@
+/*
+    knxd EIB KNX daemon
+    Copyright (C) 2026 Kwangseob Jeong <myddpp@naver.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "groupfilter.h"
+
+#include <sstream>
+
+GroupFilter::GroupFilter(const LinkConnectPtr_ &c, IniSectionPtr &s)
+    : Filter(c, s)
+{
+}
+
+bool GroupFilter::setup()
+{
+    if (!Filter::setup())
+        return false;
+
+    // Parse mode: "allow" or "block" (default)
+    std::string modeStr = cfg->value("mode", "block");
+    if (modeStr == "allow")
+        mode_ = Mode::ALLOW;
+    else if (modeStr == "block")
+        mode_ = Mode::BLOCK;
+    else
+    {
+        ERRORPRINTF(t, E_ERROR | 120, "groupfilter: unknown mode '%s', expected 'allow' or 'block'", modeStr.c_str());
+        return false;
+    }
+
+    // Parse comma-separated group addresses
+    std::string addrList = cfg->value("addresses", "");
+    if (addrList.empty())
+    {
+        ERRORPRINTF(t, E_WARNING | 121, "groupfilter: no addresses configured");
+        return true;
+    }
+
+    std::istringstream ss(addrList);
+    std::string token;
+    while (std::getline(ss, token, ','))
+    {
+        // Trim whitespace
+        size_t start = token.find_first_not_of(" \t");
+        size_t end = token.find_last_not_of(" \t");
+        if (start == std::string::npos)
+            continue;
+        token = token.substr(start, end - start + 1);
+
+        eibaddr_t addr;
+        if (!parseGroupAddress(token, addr))
+        {
+            ERRORPRINTF(t, E_ERROR | 122, "groupfilter: invalid address '%s'", token.c_str());
+            return false;
+        }
+        addresses_.insert(addr);
+    }
+
+    TRACEPRINTF(t, 1, "groupfilter: mode=%s, %d address(es)",
+                modeStr.c_str(), (int)addresses_.size());
+    return true;
+}
+
+bool GroupFilter::parseGroupAddress(const std::string &str, eibaddr_t &addr)
+{
+    unsigned int a, b, c;
+    if (sscanf(str.c_str(), "%u/%u/%u", &a, &b, &c) == 3)
+    {
+        if (a > 31 || b > 7 || c > 255)
+            return false;
+        addr = (eibaddr_t)((a << 11) | (b << 8) | c);
+        return true;
+    }
+    // Also support 2-level: a/b
+    if (sscanf(str.c_str(), "%u/%u", &a, &b) == 2)
+    {
+        if (a > 31 || b > 2047)
+            return false;
+        addr = (eibaddr_t)((a << 11) | b);
+        return true;
+    }
+    return false;
+}
+
+bool GroupFilter::shouldPass(const L_Data_PDU &pdu) const
+{
+    // Only filter group-addressed telegrams
+    if (pdu.address_type != GroupAddress)
+        return true;
+
+    bool found = addresses_.count(pdu.destination_address) > 0;
+
+    if (mode_ == Mode::ALLOW)
+        return found; // allow mode: pass only if in the set
+    else
+        return !found; // block mode: pass only if NOT in the set
+}
+
+void GroupFilter::send_L_Data(LDataPtr l)
+{
+    if (shouldPass(*l))
+        Filter::send_L_Data(std::move(l));
+    else
+    {
+        TRACEPRINTF(t, 1, "groupfilter: blocked send to %s",
+                    FormatGroupAddr(l->destination_address));
+        send_Next();
+    }
+}
+
+void GroupFilter::recv_L_Data(LDataPtr l)
+{
+    if (shouldPass(*l))
+        Filter::recv_L_Data(std::move(l));
+    else
+    {
+        TRACEPRINTF(t, 1, "groupfilter: blocked recv from %s to %s",
+                    FormatEIBAddr(l->source_address),
+                    FormatGroupAddr(l->destination_address));
+    }
+}

--- a/src/libserver/groupfilter.h
+++ b/src/libserver/groupfilter.h
@@ -1,0 +1,65 @@
+/*
+    knxd EIB KNX daemon
+    Copyright (C) 2026 Kwangseob Jeong <myddpp@naver.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef GROUPFILTER_H
+#define GROUPFILTER_H
+
+#include <unordered_set>
+#include "link.h"
+
+/**
+ * @brief Filter that allows or blocks KNX group address telegrams.
+ *
+ * Configuration (in knxd.ini section):
+ *   filter = group
+ *   mode = allow|block    (default: block)
+ *   addresses = 0/0/1,1/2/3,2/1/0   (comma-separated group addresses)
+ *
+ * In "block" mode, telegrams to listed addresses are dropped.
+ * In "allow" mode, only telegrams to listed addresses are passed through.
+ */
+RFILTER(GroupFilter, group)
+{
+public:
+    GroupFilter(const LinkConnectPtr_ &c, IniSectionPtr &s);
+    virtual ~GroupFilter() = default;
+
+    bool setup() override;
+
+    void send_L_Data(LDataPtr l) override;
+    void recv_L_Data(LDataPtr l) override;
+
+private:
+    enum class Mode
+    {
+        ALLOW,
+        BLOCK
+    };
+
+    Mode mode_ = Mode::BLOCK;
+    std::unordered_set<eibaddr_t> addresses_;
+
+    /** Parse "a/b/c" format to 16-bit group address */
+    static bool parseGroupAddress(const std::string &str, eibaddr_t &addr);
+
+    /** Check whether a packet should pass through */
+    bool shouldPass(const L_Data_PDU &pdu) const;
+};
+
+#endif /* GROUPFILTER_H */

--- a/tools/groupfilter_smoke.sh
+++ b/tools/groupfilter_smoke.sh
@@ -1,0 +1,216 @@
+#!/bin/sh
+
+# Lightweight smoke test for the group filter (#585).
+# It verifies:
+# 1) filter registration in knxd -l filter
+# 2) CLI path does not fail with "filter 'group' not found"
+# 3) INI path does not fail with "filter 'group' not found"
+# 4) behavior path blocks configured group address while allowing others
+
+set -eu
+
+log()
+{
+  echo "[groupfilter-smoke] $*"
+}
+
+ok()
+{
+  echo "[groupfilter-smoke][OK] $*"
+}
+
+fail()
+{
+  echo "[groupfilter-smoke][ERROR] $*" >&2
+}
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+KNXD="$ROOT_DIR/src/server/knxd"
+KNXTOOL="$ROOT_DIR/src/tools/knxtool"
+BEHAVIOR_PID=""
+
+if [ ! -x "$KNXD" ]; then
+  echo "ERROR: $KNXD not found or not executable. Build first (make -j4)." >&2
+  exit 1
+fi
+
+if [ ! -x "$KNXTOOL" ]; then
+  echo "ERROR: $KNXTOOL not found or not executable. Build first (make -j4)." >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+KEEP_TMP="${KEEP_TMP:-0}"
+cleanup()
+{
+  if [ -n "$BEHAVIOR_PID" ]; then
+    kill "$BEHAVIOR_PID" 2>/dev/null || true
+    wait "$BEHAVIOR_PID" 2>/dev/null || true
+  fi
+
+  if [ "$KEEP_TMP" = "1" ]; then
+    log "KEEP_TMP=1, keeping temporary files at: $TMP_DIR"
+  else
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+FILTERS_LOG="$TMP_DIR/filters.log"
+CLI_LOG="$TMP_DIR/cli.log"
+INI_LOG="$TMP_DIR/ini.log"
+INI_FILE="$TMP_DIR/groupfilter.ini"
+BEHAVIOR_LOG="$TMP_DIR/behavior.log"
+BEHAVIOR_INI="$TMP_DIR/behavior.ini"
+BEHAVIOR_SOCK="$TMP_DIR/knxd-gf.sock"
+
+"$KNXD" -l filter >"$FILTERS_LOG" 2>&1
+log "Step 1/4: checking filter registration via 'knxd -l filter'"
+if ! grep -q '^group$' "$FILTERS_LOG"; then
+  fail "group filter is not registered"
+  cat "$FILTERS_LOG" >&2
+  exit 1
+fi
+ok "group filter is registered"
+
+# Run for a short, bounded period. timeout exit 124 is expected for smoke tests.
+log "Step 2/4: checking CLI path (timeout 4s)"
+set +e
+timeout 4 "$KNXD" \
+  -e 1.1.128 -E 1.1.129:8 \
+  -D -S -i 6720 \
+  -A mode=block -A addresses=0/0/1,1/2/3 -B group \
+  -A multicast-ttl=13 -b ip: \
+  >"$CLI_LOG" 2>&1
+CLI_RC=$?
+set -e
+
+if [ "$CLI_RC" -ne 0 ] && [ "$CLI_RC" -ne 124 ]; then
+  fail "CLI run failed with unexpected exit code: $CLI_RC"
+  cat "$CLI_LOG" >&2
+  exit 1
+fi
+
+if grep -q "filter 'group' not found" "$CLI_LOG"; then
+  fail "CLI path failed to create group filter"
+  cat "$CLI_LOG" >&2
+  exit 1
+fi
+ok "CLI path passed (exit=$CLI_RC, no 'filter group not found')"
+
+cat >"$INI_FILE" <<'EOF'
+[main]
+addr = 1.1.128
+client-addrs = 1.1.129:8
+connections = router,server
+
+[server]
+server = knxd_tcp
+port = 6720
+
+[router]
+driver = ip
+multicast-ttl = 13
+filters = mygroupfilter
+
+[mygroupfilter]
+filter = group
+mode = block
+addresses = 0/0/1,1/2/3,2/1/0
+EOF
+
+log "Step 3/4: checking INI path (timeout 4s)"
+set +e
+timeout 4 "$KNXD" "$INI_FILE" >"$INI_LOG" 2>&1
+INI_RC=$?
+set -e
+
+if [ "$INI_RC" -ne 0 ] && [ "$INI_RC" -ne 124 ]; then
+  fail "INI run failed with unexpected exit code: $INI_RC"
+  cat "$INI_LOG" >&2
+  exit 1
+fi
+
+if grep -q "filter 'group' not found" "$INI_LOG"; then
+  fail "INI path failed to create group filter"
+  cat "$INI_LOG" >&2
+  exit 1
+fi
+ok "INI path passed (exit=$INI_RC, no 'filter group not found')"
+
+cat >"$BEHAVIOR_INI" <<EOF
+[main]
+addr = 1.1.128
+client-addrs = 1.1.129:8
+connections = unix,dummy
+
+[unix]
+server = knxd_unix
+path = $BEHAVIOR_SOCK
+
+[dummy]
+driver = dummy
+filters = mygroupfilter,mylog
+
+[mygroupfilter]
+filter = group
+mode = block
+addresses = 1/2/3
+debug = debug-gf
+
+[mylog]
+filter = log
+debug = debug-log
+
+[debug-gf]
+trace-mask = 0xffff
+error-level = 9
+
+[debug-log]
+trace-mask = 0xffff
+error-level = 9
+EOF
+
+log "Step 4/4: checking behavior path (blocked 1/2/3, passed 1/2/4)"
+"$KNXD" "$BEHAVIOR_INI" >"$BEHAVIOR_LOG" 2>&1 &
+BEHAVIOR_PID=$!
+
+# Wait briefly for the unix socket to appear.
+i=0
+while [ ! -S "$BEHAVIOR_SOCK" ] && [ "$i" -lt 30 ]; do
+  i=$((i + 1))
+  sleep 0.1
+done
+
+if [ ! -S "$BEHAVIOR_SOCK" ]; then
+  fail "behavior test socket was not created"
+  cat "$BEHAVIOR_LOG" >&2
+  exit 1
+fi
+
+"$KNXTOOL" groupswrite local:"$BEHAVIOR_SOCK" 1/2/3 01 >/dev/null 2>&1
+"$KNXTOOL" groupswrite local:"$BEHAVIOR_SOCK" 1/2/4 01 >/dev/null 2>&1
+sleep 0.5
+
+if ! grep -q "groupfilter: blocked send to 1/2/3" "$BEHAVIOR_LOG"; then
+  fail "blocked telegram evidence not found for 1/2/3"
+  cat "$BEHAVIOR_LOG" >&2
+  exit 1
+fi
+
+if ! grep -Eq "Send L_Data low .* to 1/2/4 " "$BEHAVIOR_LOG"; then
+  fail "pass-through telegram evidence not found for 1/2/4"
+  cat "$BEHAVIOR_LOG" >&2
+  exit 1
+fi
+
+if grep -Eq "Send L_Data low .* to 1/2/3 " "$BEHAVIOR_LOG"; then
+  fail "blocked address 1/2/3 unexpectedly passed beyond group filter"
+  cat "$BEHAVIOR_LOG" >&2
+  exit 1
+fi
+
+ok "behavior path passed (1/2/3 blocked, 1/2/4 passed)"
+
+log "All checks passed"
+echo "groupfilter smoke: OK"


### PR DESCRIPTION
Add a 'group' filter to allow/block telegrams by group address. 

Supports both allow/block mode and 2/3-level group address format.

Ensure runtime registration in static-link builds and add a lightweight smoke test for CLI/INI paths.

Fixes: #585